### PR TITLE
Add UCSBOrganization Table, Util, and Tests

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,38 @@
+const organizationFixtures = {
+    oneOrganization:
+    [
+      {
+        "orgCode": "VSA",
+        "orgTranslationShort": "Viet Stu Assc",
+        "orgTranslation": "Vietnamese Student Association",
+        "inactive": false  
+      }
+    ],
+
+    threeOrganizations:
+    [
+        {
+            "orgCode": "TT",
+            "orgTranslationShort": "Theta Tau",
+            "orgTranslation": "Theta Tau",
+            "inactive": false  
+        },
+
+        {
+            "orgCode": "TASA",
+            "orgTranslationShort": "Tai Amer Stu Assc",
+            "orgTranslation": "Taiwanese American Student Association",
+            "inactive": false  
+        },
+
+        {
+            "orgCode": "DEM",
+            "orgTranslationShort": "Delt Ep Mu",
+            "orgTranslation": "Delta Epsilon Mu",
+            "inactive": true    
+        },
+        
+    ]
+};
+
+export { organizationFixtures };

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,4 +1,4 @@
-const organizationFixtures = {
+const UCSBOrganizationFixtures = {
     oneOrganization:
     [
       {
@@ -35,4 +35,4 @@ const organizationFixtures = {
     ]
 };
 
-export { organizationFixtures };
+export { UCSBOrganizationFixtures };

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,38 +1,31 @@
-const UCSBOrganizationFixtures = {
-    oneOrganization:
-    [
-      {
+const ucsbOrganizationFixtures = {
+    oneOrganization: {
         "orgCode": "VSA",
-        "orgTranslationShort": "Viet Stu Assc",
-        "orgTranslation": "Vietnamese Student Association",
-        "inactive": false  
-      }
-    ],
-
-    threeOrganizations:
-    [
+        "orgTranslationShort": "VIET STU ASSC",
+        "orgTranslation": "VIETNAMESE STUDENT ASSOCIATION",
+        "inactive": false
+    },
+    threeOrganization: [
+        {
+            "orgCode": "VSA",
+            "orgTranslationShort": "VIET STU ASSC",
+            "orgTranslation": "VIETNAMESE STUDENT ASSOCIATION",
+            "inactive": false
+        },
         {
             "orgCode": "TT",
-            "orgTranslationShort": "Theta Tau",
-            "orgTranslation": "Theta Tau",
-            "inactive": false  
+            "orgTranslationShort": "THETA TAU",
+            "orgTranslation": "THETA TAU",
+            "inactive": false
         },
-
-        {
-            "orgCode": "TASA",
-            "orgTranslationShort": "Tai Amer Stu Assc",
-            "orgTranslation": "Taiwanese American Student Association",
-            "inactive": false  
-        },
-
         {
             "orgCode": "DEM",
-            "orgTranslationShort": "Delt Ep Mu",
-            "orgTranslation": "Delta Epsilon Mu",
-            "inactive": true    
-        },
-        
+            "orgTranslationShort": "DEL EP MU",
+            "orgTranslation": "DELTA EPSILON MU",
+            "inactive": false
+        }
     ]
 };
 
-export { UCSBOrganizationFixtures };
+
+export { ucsbOrganizationFixtures };

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -3,26 +3,26 @@ const ucsbOrganizationFixtures = {
         "orgCode": "VSA",
         "orgTranslationShort": "VIET STU ASSC",
         "orgTranslation": "VIETNAMESE STUDENT ASSOCIATION",
-        "inactive": false
+        "inactive": "false"
     },
     threeOrganization: [
         {
             "orgCode": "VSA",
             "orgTranslationShort": "VIET STU ASSC",
             "orgTranslation": "VIETNAMESE STUDENT ASSOCIATION",
-            "inactive": false
+            "inactive": "false"
         },
         {
             "orgCode": "TT",
             "orgTranslationShort": "THETA TAU",
             "orgTranslation": "THETA TAU",
-            "inactive": false
+            "inactive": "false"
         },
         {
             "orgCode": "DEM",
             "orgTranslationShort": "DEL EP MU",
             "orgTranslation": "DELTA EPSILON MU",
-            "inactive": false
+            "inactive": "false"
         }
     ]
 };

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -14,7 +14,6 @@ function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Cr
         { defaultValues: initialContents || {}, }
     );
     // Stryker restore all
-
     const navigate = useNavigate();
 
     const testIdPrefix = "UCSBOrganizationForm";

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -21,19 +21,21 @@ function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Cr
     return (
         <Form onSubmit={handleSubmit(submitAction)}>
 
-            {initialContents && (
-                <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="orgCode">orgCode</Form.Label>
-                    <Form.Control
-                        data-testid={testIdPrefix + "-orgCode"}
-                        id="orgCode"
-                        type="text"
-                        {...register("orgCode")}
-                        value={initialContents.orgCode}
-                        disabled
-                    />
-                </Form.Group>
-            )}
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgCode">orgCode</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgCode"}
+                    id="orgCode"
+                    type="text"
+                    isInvalid={Boolean(errors.orgCode)}
+                    {...register("orgCode", {
+                        required: "orgCode is required.",
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgCode?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
 
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="orgTranslationShort">orgTranslationShort</Form.Label>

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -1,0 +1,108 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+
+    const navigate = useNavigate();
+
+    const testIdPrefix = "UCSBOrganizationForm";
+
+    return (
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="orgCode">orgCode</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-orgCode"}
+                        id="orgCode"
+                        type="text"
+                        {...register("orgCode")}
+                        value={initialContents.orgCode}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgTranslationShort">orgTranslationShort</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgTranslationShort"}
+                    id="orgTranslationShort"
+                    type="text"
+                    isInvalid={Boolean(errors.orgTranslationShort)}
+                    {...register("orgTranslationShort", {
+                        required: "orgTranslationShort is required.",
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgTranslationShort?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgTranslation">orgTranslation</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgTranslation"}
+                    id="orgTranslation"
+                    type="text"
+                    isInvalid={Boolean(errors.orgTranslation)}
+                    {...register("orgTranslation", {
+                        required: "orgTranslation is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgTranslation?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="inactive">inactive</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-inactive"}
+                    id="inactive"
+                    type="Boolean"
+                    isInvalid={Boolean(errors.inactive)}
+                    {...register("inactive", {
+                        required: "inactive is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.inactive?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default UCSBOrganizationForm;

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -1,0 +1,59 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBOrganizationUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function UCSBOrganizationTable({ organizations, currentUser }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/ucsborganization/edit/${cell.row.values.orgCode}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/ucsborganization/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+
+    const columns = [
+        {
+            Header: 'orgCode',
+            accessor: 'orgCode', // accessor is the "key" in the data
+        },
+        {
+            Header: 'orgTranslationShort',
+            accessor: 'orgTranslationShort',
+        },
+        {
+            Header: 'orgTranslation',
+            accessor: 'orgTranslation',
+        },
+        {
+            Header: 'inactive',
+            accessor: 'inactive',
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "UCSBOrganizationTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "UCSBOrganizationTable"));
+    } 
+
+    return <OurTable
+        data={organizations}
+        columns={columns}
+        testid={"UCSBOrganizationTable"}
+    />;
+};

--- a/frontend/src/main/utils/UCSBOrganizationUtils.js
+++ b/frontend/src/main/utils/UCSBOrganizationUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/ucsborganization",
+        method: "DELETE",
+        params: {
+            orgCode: cell.row.values.orgCode
+        }
+    }
+}
+

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.js
@@ -12,7 +12,6 @@ const Template = (args) => {
         <UCSBOrganizationForm {...args} />
     )
 };
-
 export const Create = Template.bind({});
 
 Create.args = {

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm"
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+
+export default {
+    title: 'components/UCSBOrganization/UCSBOrganizationForm',
+    component: UCSBOrganizationForm
+};
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+         console.log("Submit was clicked with data: ", data); 
+         window.alert("Submit was clicked with data: " + JSON.stringify(data));
+    }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: ucsbOrganizationFixtures.oneOrganization[0],
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/UCSBOrganization/UCSBOrganizationTable',
+    component: UCSBOrganizationTable
+};
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    organizations: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    organizations: ucsbOrganizationFixtures.threeOrganization,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    organizations: ucsbOrganizationFixtures.threeOrganization,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/ucsborganization', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};
+

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -23,7 +23,6 @@ describe("UCSBOrganizationForm tests", () => {
         await screen.findByText(/Create/);
     });
 
-
     test("renders correctly when passing in a UCSBOrganization", async () => {
 
         render(

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -1,0 +1,124 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("UCSBOrganizationForm tests", () => {
+
+    test("renders correctly", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm />
+            </Router>
+        );
+        await screen.findByText(/Create/);
+    });
+
+
+    test("renders correctly when passing in a UCSBOrganization", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm initialContents={ucsbOrganizationFixtures.oneOrganization} />
+            </Router>
+        );
+        
+        await screen.findByTestId(/UCSBOrganizationForm-orgCode/);
+        expect(screen.getByText(/orgCode/)).toBeInTheDocument();
+        expect(screen.getByTestId(/UCSBOrganizationForm-orgCode/)).toHaveValue("VSA");
+    });
+
+
+    test("Correct Error messsages on bad input", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm />
+            </Router>
+        );
+        await screen.findByTestId("UCSBOrganizationForm-orgTranslationShort");
+        const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
+        const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
+        const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+        fireEvent.change(orgTranslationShortField, { target: { value: 'bad-input' } });
+        fireEvent.change(orgTranslationField, { target: { value: 'bad-input' } });
+        fireEvent.click(submitButton);
+
+        expect(screen.queryByText(/orgTranslationShort must be a string/)).not.toBeInTheDocument();
+    });
+
+    test("Correct Error messsages on missing input", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm />
+            </Router>
+        );
+        await screen.findByTestId("UCSBOrganizationForm-submit");
+        const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/orgTranslationShort is required./);
+        expect(screen.getByText(/orgTranslation is required./)).toBeInTheDocument();
+        expect(screen.getByText(/inactive is required./)).toBeInTheDocument();
+
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("UCSBOrganizationForm-orgTranslationShort");
+
+        const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
+        const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
+        const inactive = screen.getByTestId("UCSBOrganizationForm-inactive");
+        const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+        fireEvent.change(orgTranslationShortField, { target: { value: 'VIET STU ASSC' } });
+        fireEvent.change(orgTranslationField, { target: { value: 'VIETNAMESE STUDENT ASSOCIATION' } });
+        fireEvent.change(inactive, { target: { value: false } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(screen.queryByText(/orgTranslationShort must be a string/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/orgTranslation must be a string/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm />
+            </Router>
+        );
+        await screen.findByTestId("UCSBOrganizationForm-cancel");
+        const cancelButton = screen.getByTestId("UCSBOrganizationForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -86,11 +86,13 @@ describe("UCSBOrganizationForm tests", () => {
         );
         await screen.findByTestId("UCSBOrganizationForm-orgTranslationShort");
 
+        const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
         const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
         const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
         const inactive = screen.getByTestId("UCSBOrganizationForm-inactive");
         const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
 
+        fireEvent.change(orgCodeField, { target: { value: 'VSA' } });
         fireEvent.change(orgTranslationShortField, { target: { value: 'VIET STU ASSC' } });
         fireEvent.change(orgTranslationField, { target: { value: 'VIETNAMESE STUDENT ASSOCIATION' } });
         fireEvent.change(inactive, { target: { value: false } });

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
@@ -1,0 +1,186 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBOrganizationTable tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["orgCode", "orgTranslationShort", "orgTranslation", "inactive"];
+    const expectedFields = ["orgCode", "orgTranslationShort", "orgTranslation", "inactive"];
+    const testId = "UCSBOrganizationTable";
+
+    test("renders empty table correctly", () => {
+    
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={ucsbOrganizationFixtures.threeOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("false");
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("false");
+
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={ucsbOrganizationFixtures.threeOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={ucsbOrganizationFixtures.threeOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsborganization/edit/VSA'));
+
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={ucsbOrganizationFixtures.threeOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+  });
+
+  
+});

--- a/frontend/src/tests/utils/UCSBOrganizationUtils.test.js
+++ b/frontend/src/tests/utils/UCSBOrganizationUtils.test.js
@@ -1,0 +1,53 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/UCSBOrganizationUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBOrganizationUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { orgCode: "VSA" } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/ucsborganization",
+                method: "DELETE",
+                params: { orgCode: "VSA" }
+            });
+        });
+
+    });
+});

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,107 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/ucsborganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @Operation(summary= "List all ucsb organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allOrganizations() {
+        Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+        return organizations;
+    }
+
+    @Operation(summary= "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrganization(
+        @Parameter(name="orgCode") @RequestParam String orgCode,
+        @Parameter(name="orgTranslationShort") @RequestParam String orgTranslationShort,
+        @Parameter(name="orgTranslation") @RequestParam String orgTranslation,
+        @Parameter(name="inactive") @RequestParam boolean inactive
+        )
+        {
+
+        UCSBOrganization organization = new UCSBOrganization();
+        organization.setOrgCode(orgCode);
+        organization.setOrgTranslationShort(orgTranslationShort);
+        organization.setOrgTranslation(orgTranslation);
+        organization.setInactive(inactive);
+
+        UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
+
+        return savedOrganization;
+    }
+
+    @Operation(summary= "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return organization;
+    }
+
+    @Operation(summary= "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        organization.setOrgCode(incoming.getOrgCode());
+        organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        organization.setOrgTranslation(incoming.getOrgTranslation());
+        organization.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(organization);
+
+        return organization;
+    }
+
+    @Operation(summary= "Delete a UCSBOrganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteCommons(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        ucsbOrganizationRepository.delete(organization);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganization")
+public class UCSBOrganization {
+    @Id
+    private String orgCode;
+    private String orgTranslationShort;
+    private String orgTranslation;
+    private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+ 
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,395 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+   
+    @MockBean
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/ucsborganization/all
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsborganization/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsborganization/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(ucsbOrganizationRepository.findById(eq("TASA"))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=TASA"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(ucsbOrganizationRepository, times(1)).findById(eq("TASA"));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("UCSBOrganization with id TASA not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_organization() throws Exception {
+
+            // arrange
+
+            UCSBOrganization zetaPhiRho = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETA PHI RHO")
+                            .orgTranslation("ZETA PHI RHO")
+                            .inactive(false)
+                            .build();
+
+            UCSBOrganization skydiving = UCSBOrganization.builder()
+                            .orgCode("SKY")
+                            .orgTranslationShort("SKYDIVING CLUB")
+                            .orgTranslation("SKYDIVING CLUB AT UCSB")
+                            .inactive(false)
+                            .build();
+
+            UCSBOrganization studentLife = UCSBOrganization.builder()
+                            .orgCode("OSLI")
+                            .orgTranslationShort("STUDENT LIFE")
+                            .orgTranslation("OFFICE OF STUDENT LIFE")
+                            .inactive(false)
+                            .build();
+
+            UCSBOrganization koreanRadio = UCSBOrganization.builder()
+                            .orgCode("KRC")
+                            .orgTranslationShort("KOREAN RADIO CL")
+                            .orgTranslation("KOREAN RADIO CLUB")
+                            .inactive(false)
+                            .build();
+
+            ArrayList<UCSBOrganization> expectedOrganization = new ArrayList<>();
+            expectedOrganization.addAll(Arrays.asList(zetaPhiRho, skydiving, studentLife, koreanRadio));
+
+            when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganization);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsborganization/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(ucsbOrganizationRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedOrganization);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for POST /api/ucsborganization...
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsborganization/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsborganization/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_organization() throws Exception {
+            // arrange
+
+            UCSBOrganization csu = UCSBOrganization.builder()
+                            .orgCode("CSU")
+                            .orgTranslationShort("CHINESE STU UN")
+                            .orgTranslation("CHINESE STUDENT UNION")
+                            .inactive(false)
+                            .build();
+
+            when(ucsbOrganizationRepository.save(eq(csu))).thenReturn(csu);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/ucsborganization/post?orgCode=CSU&orgTranslationShort=CHINESE STU UN&orgTranslation=CHINESE STUDENT UNION&inactive=false")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).save(csu);
+            String expectedJson = mapper.writeValueAsString(csu);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for GET /api/ucsborganization?...
+
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/ucsborganization?orgCode=ZPR"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+            // arrange
+
+            UCSBOrganization organization = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETA PHI RHO")
+                            .orgTranslation("ZETA PHI RHO")
+                            .inactive(false)
+                            .build();
+
+            when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(organization));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=ZPR"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(ucsbOrganizationRepository, times(1)).findById(eq("ZPR"));
+            String expectedJson = mapper.writeValueAsString(organization);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for PUT /api/ucsborganization?...
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_organization() throws Exception {
+            // arrange
+
+            UCSBOrganization zetaPhiRhoOrig = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETA PHI RHO")
+                            .orgTranslation("ZETA PHI RHO")
+                            .inactive(false)
+                            .build();
+
+            UCSBOrganization zetaPhiRhoEdited = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETAS")
+                            .orgTranslation("ZETA PHI RHOS")
+                            .inactive(true)
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(zetaPhiRhoEdited);
+
+            when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(zetaPhiRhoOrig));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/ucsborganization?orgCode=ZPR")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+            verify(ucsbOrganizationRepository, times(1)).save(zetaPhiRhoEdited); // should be saved with updated info
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+    }
+
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+            // arrange
+
+            UCSBOrganization editedOrg = UCSBOrganization.builder()
+                            .orgCode("TASA")
+                            .orgTranslationShort("TAI AMER STU ASSC")
+                            .orgTranslation("TAIWANESE AMERICAN STUDENT ASSOCIATION")
+                            .inactive(false)
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(editedOrg);
+
+            when(ucsbOrganizationRepository.findById(eq("TASA"))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/ucsborganization?orgCode=TASA")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findById("TASA");
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("UCSBOrganization with id TASA not found", json.get("message"));
+
+    }
+
+    // Tests for DELETE /api/ucsborganization?...
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_date() throws Exception {
+            // arrange
+
+            UCSBOrganization zetaPhiRho = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETA PHI RHO")
+                            .orgTranslation("ZETA PHI RHO")
+                            .inactive(false)
+                            .build();
+
+            when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(zetaPhiRho));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/ucsborganization?orgCode=ZPR")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+            verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("UCSBOrganization with id ZPR deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_organization_and_gets_right_error_message()
+                    throws Exception {
+            // arrange
+
+            when(ucsbOrganizationRepository.findById(eq("TASA"))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/ucsborganization?orgCode=TASA")
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findById("TASA");
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("UCSBOrganization with id TASA not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_post_inactive_organization() throws Exception {
+        // arrange
+        UCSBOrganization vsa = UCSBOrganization.builder()
+                .orgCode("VSA")
+                .orgTranslationShort("Viet Stu Assc")
+                .orgTranslation("Vietnamese Student Association")
+                .inactive(true)
+                .build();
+
+        when(ucsbOrganizationRepository.save(eq(vsa))).thenReturn(vsa);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/ucsborganization/post?orgCode=VSA&orgTranslationShort=Viet Stu Assc&orgTranslation=Vietnamese Student Association&inactive=true")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).save(vsa);
+        String expectedJson = mapper.writeValueAsString(vsa);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+        }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_update_orgcode() throws Exception {
+        // arrange
+
+        UCSBOrganization zetaPhiRhoOrig = UCSBOrganization.builder()
+        .orgCode("ZPR")
+        .orgTranslationShort("ZETA PHI RHO")
+        .orgTranslation("ZETA PHI RHO")
+        .inactive(false)
+        .build();
+
+        UCSBOrganization zetaPhiRhoEdited = UCSBOrganization.builder()
+                .orgCode("ZPRNEW")
+                .orgTranslationShort("ZETAS")
+                .orgTranslation("ZETA PHI RHOS")
+                .inactive(true)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(zetaPhiRhoEdited);
+
+        when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(zetaPhiRhoOrig));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/ucsborganization?orgCode=ZPR")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                                .content(requestBody)
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+        verify(ucsbOrganizationRepository, times(1)).save(zetaPhiRhoEdited); // should be saved with updated info
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(requestBody, responseString);
+    }
+}


### PR DESCRIPTION
In this PR, I added UCSBOrganization table, utils, and test files. UCSBOrganization Table now appears in Storybook, as shown below:
<img width="1440" alt="PNG image" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/91717567/d766b766-5777-4461-97de-25d427c51b57">
<img width="1440" alt="PNG image" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/91717567/c928858a-e44f-4219-a980-7bb6b4f762c2">

Closes #20 
