### PR TITLE
Add UCSBOrganization Form, Table Components + Create, Edit, Index Pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -90,7 +90,7 @@ function App() {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
               <Route exact path="/ucsborganization/edit/:id" element={<UCSBOrganizationEditPage />} />
-              <Route exact path="/ucsborganizaiton/create" element={<UCSBOrganizationCreatePage />} />
+              <Route exact path="/ucsborganization/create" element={<UCSBOrganizationCreatePage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -89,7 +89,7 @@ function App() {
         {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
-              <Route exact path="/ucsborganization/edit/:id" element={<UCSBOrganizationEditPage />} />
+              <Route exact path="/ucsborganization/edit/:orgCode" element={<UCSBOrganizationEditPage />} />
               <Route exact path="/ucsborganization/create" element={<UCSBOrganizationCreatePage />} />
             </>
           )

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,9 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -73,6 +76,21 @@ function App() {
             <>
               <Route exact path="/placeholder/edit/:id" element={<PlaceholderEditPage />} />
               <Route exact path="/placeholder/create" element={<PlaceholderCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/ucsborganization" element={<UCSBOrganizationIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/ucsborganization/edit/:id" element={<UCSBOrganizationEditPage />} />
+              <Route exact path="/ucsborganizaiton/create" element={<UCSBOrganizationCreatePage />} />
             </>
           )
         }

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,38 @@
+const organizationFixtures = {
+    oneOrganization:
+    [
+      {
+        "orgCode": "VSA",
+        "orgTranslationShort": "Viet Stu Assc",
+        "orgTranslation": "Vietnamese Student Association",
+        "inactive": false  
+      }
+    ],
+
+    threeOrganizations:
+    [
+        {
+            "orgCode": "TT",
+            "orgTranslationShort": "Theta Tau",
+            "orgTranslation": "Theta Tau",
+            "inactive": false  
+        },
+
+        {
+            "orgCode": "TASA",
+            "orgTranslationShort": "Tai Amer Stu Assc",
+            "orgTranslation": "Taiwanese American Student Association",
+            "inactive": false  
+        },
+
+        {
+            "orgCode": "DEM",
+            "orgTranslationShort": "Delt Ep Mu",
+            "orgTranslation": "Delta Epsilon Mu",
+            "inactive": true    
+        },
+        
+    ]
+};
+
+export { organizationFixtures };

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,4 +1,4 @@
-const organizationFixtures = {
+const UCSBOrganizationFixtures = {
     oneOrganization:
     [
       {
@@ -35,4 +35,4 @@ const organizationFixtures = {
     ]
 };
 
-export { organizationFixtures };
+export { UCSBOrganizationFixtures };

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,38 +1,31 @@
-const UCSBOrganizationFixtures = {
-    oneOrganization:
-    [
-      {
+const ucsbOrganizationFixtures = {
+    oneOrganization: {
         "orgCode": "VSA",
-        "orgTranslationShort": "Viet Stu Assc",
-        "orgTranslation": "Vietnamese Student Association",
-        "inactive": false  
-      }
-    ],
-
-    threeOrganizations:
-    [
+        "orgTranslationShort": "VIET STU ASSC",
+        "orgTranslation": "VIETNAMESE STUDENT ASSOCIATION",
+        "inactive": false
+    },
+    threeOrganization: [
+        {
+            "orgCode": "VSA",
+            "orgTranslationShort": "VIET STU ASSC",
+            "orgTranslation": "VIETNAMESE STUDENT ASSOCIATION",
+            "inactive": false
+        },
         {
             "orgCode": "TT",
-            "orgTranslationShort": "Theta Tau",
-            "orgTranslation": "Theta Tau",
-            "inactive": false  
+            "orgTranslationShort": "THETA TAU",
+            "orgTranslation": "THETA TAU",
+            "inactive": false
         },
-
-        {
-            "orgCode": "TASA",
-            "orgTranslationShort": "Tai Amer Stu Assc",
-            "orgTranslation": "Taiwanese American Student Association",
-            "inactive": false  
-        },
-
         {
             "orgCode": "DEM",
-            "orgTranslationShort": "Delt Ep Mu",
-            "orgTranslation": "Delta Epsilon Mu",
-            "inactive": true    
-        },
-        
+            "orgTranslationShort": "DEL EP MU",
+            "orgTranslation": "DELTA EPSILON MU",
+            "inactive": false
+        }
     ]
 };
 
-export { UCSBOrganizationFixtures };
+
+export { ucsbOrganizationFixtures };

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -3,26 +3,26 @@ const ucsbOrganizationFixtures = {
         "orgCode": "VSA",
         "orgTranslationShort": "VIET STU ASSC",
         "orgTranslation": "VIETNAMESE STUDENT ASSOCIATION",
-        "inactive": false
+        "inactive": "false"
     },
     threeOrganization: [
         {
             "orgCode": "VSA",
             "orgTranslationShort": "VIET STU ASSC",
             "orgTranslation": "VIETNAMESE STUDENT ASSOCIATION",
-            "inactive": false
+            "inactive": "false"
         },
         {
             "orgCode": "TT",
             "orgTranslationShort": "THETA TAU",
             "orgTranslation": "THETA TAU",
-            "inactive": false
+            "inactive": "false"
         },
         {
             "orgCode": "DEM",
             "orgTranslationShort": "DEL EP MU",
             "orgTranslation": "DELTA EPSILON MU",
-            "inactive": false
+            "inactive": "false"
         }
     ]
 };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,6 +57,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
+                  <Nav.Link as={Link} to="/ucsborganization">UCSB Organizations</Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -1,0 +1,109 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+    const navigate = useNavigate();
+
+    const testIdPrefix = "UCSBOrganizationForm";
+
+    return (
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgCode">orgCode</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgCode"}
+                    id="orgCode"
+                    type="text"
+                    isInvalid={Boolean(errors.orgCode)}
+                    {...register("orgCode", {
+                        required: "orgCode is required.",
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgCode?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgTranslationShort">orgTranslationShort</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgTranslationShort"}
+                    id="orgTranslationShort"
+                    type="text"
+                    isInvalid={Boolean(errors.orgTranslationShort)}
+                    {...register("orgTranslationShort", {
+                        required: "orgTranslationShort is required.",
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgTranslationShort?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgTranslation">orgTranslation</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgTranslation"}
+                    id="orgTranslation"
+                    type="text"
+                    isInvalid={Boolean(errors.orgTranslation)}
+                    {...register("orgTranslation", {
+                        required: "orgTranslation is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgTranslation?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="inactive">inactive</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-inactive"}
+                    id="inactive"
+                    type="Boolean"
+                    isInvalid={Boolean(errors.inactive)}
+                    {...register("inactive", {
+                        required: "inactive is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.inactive?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default UCSBOrganizationForm;

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -77,7 +77,8 @@ function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Cr
                     type="Boolean"
                     isInvalid={Boolean(errors.inactive)}
                     {...register("inactive", {
-                        required: "inactive is required."
+                        required: "inactive is required.",
+                        validate: value => value === 'true' || value === 'false' || "The input should be just true or false" 
                     })}
                 />
                 <Form.Control.Feedback type="invalid">

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -43,6 +43,8 @@ export default function UCSBOrganizationTable({ organizations, currentUser }) {
         {
             Header: 'inactive',
             accessor: 'inactive',
+            Cell: ({ value }) => value.toString()  // Explicitly convert boolean to string
+
         }
     ];
 

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -1,0 +1,59 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBOrganizationUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function UCSBOrganizationTable({ organizations, currentUser }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/ucsborganization/edit/${cell.row.values.orgCode}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/ucsborganization/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+
+    const columns = [
+        {
+            Header: 'orgCode',
+            accessor: 'orgCode', // accessor is the "key" in the data
+        },
+        {
+            Header: 'orgTranslationShort',
+            accessor: 'orgTranslationShort',
+        },
+        {
+            Header: 'orgTranslation',
+            accessor: 'orgTranslation',
+        },
+        {
+            Header: 'inactive',
+            accessor: 'inactive',
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "UCSBOrganizationTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "UCSBOrganizationTable"));
+    } 
+
+    return <OurTable
+        data={organizations}
+        columns={columns}
+        testid={"UCSBOrganizationTable"}
+    />;
+};

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.js
@@ -1,0 +1,49 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function UCSBOrganizationCreatePage({storybook=false}) {
+
+  const objectToAxiosParams = (organization) => ({
+    url: "/api/ucsborganization/post",
+    method: "POST",
+    params: {
+     orgCode: organization.orgCode,
+     orgTranslationShort: organization.orgTranslationShort,
+     orgTranslation: organization.orgTranslation,
+     inactive: organization.inactive
+    }
+  });
+
+  const onSuccess = (organization) => {
+    toast(`New organization Created - orgCode: ${organization.orgCode} orgTranslationShort: ${organization.orgTranslationShort} orgTranslation: ${organization.orgTranslation} inactive: ${organization.inactive}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/ucsborganization/all"] // mutation makes this key stale so that pages relying on it reload
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New Organization</h1>
+        <UCSBOrganizationForm submitAction={onSubmit} />
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBOrganizationEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.js
@@ -1,13 +1,71 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import UCSBOrganizationForm from 'main/components/UCSBOrganization/UCSBOrganizationForm';
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationEditPage() {
+export default function UCSBOrganizationEditPage({storybook=false}) {
+    let { orgCode } = useParams();
+    
+    const { data: organization, _error, _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/ucsborganization?orgCode=${orgCode}`],
+            {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/ucsborganization`,
+                params: {
+                    orgCode
+                }
+            }
+        );
 
-  // Stryker disable all : placeholder for future implementation
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
-      </div>
-    </BasicLayout>
-  )
+
+    const objectToAxiosPutParams = (organization) => ({
+        url: "/api/ucsborganization",
+        method: "PUT",
+        params: {
+            orgCode: organization.orgCode,
+        },
+        data: {
+            orgCode: organization.orgCode,
+            orgTranslationShort: organization.orgTranslationShort,
+            orgTranslation: organization.orgTranslation,
+            inactive: organization.inactive
+        }
+    });
+
+    const onSuccess = (organization) => {
+        toast(`UCSBOrganization Updated - orgCode: ${organization.orgCode} orgTranslationShort: ${organization.orgTranslationShort} orgTranslation: ${organization.orgTranslation} inactive: ${organization.inactive}`);
+    }
+
+    const mutation = useBackendMutation(
+        objectToAxiosPutParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/ucsborganization?orgCode=${orgCode}`]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    }
+
+    if (isSuccess && !storybook) {
+        return <Navigate to="/ucsborganization" />
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Edit UCSBOrganization</h1>
+                {
+                    organization && <UCSBOrganizationForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={organization} />
+                }
+            </div>
+        </BasicLayout>
+    )
+
 }

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
@@ -8,7 +8,7 @@ export default function UCSBOrganizationIndexPage() {
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
         <p><a href="/ucsborganization/create">Create</a></p>
-        <p><a href="/ucsborganization/edit/1">Edit</a></p>
+        <p><a href="/placeholder/edit/1">Edit</a></p>
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBOrganizationIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/placeholder/create">Create</a></p>
+        <p><a href="/placeholder/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
@@ -1,15 +1,45 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationTable from 'main/components/UCSBOrganization/UCSBOrganizationTable';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser'
+import { Button } from 'react-bootstrap';
 
 export default function UCSBOrganizationIndexPage() {
 
-  // Stryker disable all : placeholder for future implementation
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/ucsborganization/create">Create</a></p>
-        <p><a href="/placeholder/edit/1">Edit</a></p>
-      </div>
-    </BasicLayout>
-  )
+    const currentUser = useCurrentUser();
+
+    const { data: organizations, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            ["/api/ucsborganization/all"],
+            { method: "GET", url: "/api/ucsborganization/all" },
+            // Stryker disable next-line all : don't test default value of empty list
+            []
+        );
+
+    const createButton = () => {
+        if (hasRole(currentUser, "ROLE_ADMIN")) {
+            return (
+                <Button
+                    variant="primary"
+                    href="/ucsborganization/create"
+                    style={{ float: "right" }}
+                >
+                    Create Organization
+                </Button>
+            )
+        } 
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                {createButton()}
+                <h1>Organizations</h1>
+                <UCSBOrganizationTable organizations={organizations} currentUser={currentUser} />
+            </div>
+        </BasicLayout>
+    );
 }

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.js
@@ -7,8 +7,8 @@ export default function UCSBOrganizationIndexPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
-        <p><a href="/placeholder/create">Create</a></p>
-        <p><a href="/placeholder/edit/1">Edit</a></p>
+        <p><a href="/ucsborganization/create">Create</a></p>
+        <p><a href="/ucsborganization/edit/1">Edit</a></p>
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/UCSBOrganizationUtils.js
+++ b/frontend/src/main/utils/UCSBOrganizationUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/ucsborganization",
+        method: "DELETE",
+        params: {
+            orgCode: cell.row.values.orgCode
+        }
+    }
+}
+

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm"
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+
+export default {
+    title: 'components/UCSBOrganization/UCSBOrganizationForm',
+    component: UCSBOrganizationForm
+};
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationForm {...args} />
+    )
+};
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+         console.log("Submit was clicked with data: ", data); 
+         window.alert("Submit was clicked with data: " + JSON.stringify(data)); 
+    }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: ucsbOrganizationFixtures.oneOrganization[0],
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/UCSBOrganization/UCSBOrganizationTable',
+    component: UCSBOrganizationTable
+};
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    organizations: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    organizations: ucsbOrganizationFixtures.threeOrganization,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    organizations: ucsbOrganizationFixtures.threeOrganization,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/ucsborganization', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};
+

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage"
+
+export default {
+    title: 'pages/UCSBOrganization/UCSBOrganizationCreatePage',
+    component: UCSBOrganizationCreatePage
+};
+
+const Template = () => <UCSBOrganizationCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/ucsborganization/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+
+export default {
+    title: 'pages/UCSBOrganization/UCSBOrganizationEditPage',
+    component: UCSBOrganizationEditPage
+};
+
+const Template = () => <UCSBOrganizationEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsborganization', (_req, res, ctx) => {
+            return res(ctx.json(ucsbOrganizationFixtures.threeOrganization[0]));
+        }),
+        rest.put('/api/ucsborganization', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}
+
+
+

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationIndexPage.stories.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { rest } from "msw";
+
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+
+export default {
+    title: 'pages/UCSBOrganization/UCSBOrganizationIndexPage',
+    component: UCSBOrganizationIndexPage
+};
+
+const Template = () => <UCSBOrganizationIndexPage storybook={true}/>;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsborganization/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        }),
+    ]
+}
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsborganization/all', (_req, res, ctx) => {
+            return res(ctx.json(ucsbOrganizationFixtures.threeOrganization));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsborganization/all', (_req, res, ctx) => {
+            return res(ctx.json(ucsbOrganizationFixtures.threeOrganization));
+        }),
+        rest.delete('/api/ucsborganization', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -76,6 +76,29 @@ describe("UCSBOrganizationForm tests", () => {
 
     });
 
+    test("Displays error message for invalid 'inactive' input", async () => {
+        render(
+            <Router>
+                <UCSBOrganizationForm />
+            </Router>
+        );
+    
+        // Wait for the 'inactive' input field to appear
+        const inactiveField = await screen.findByTestId("UCSBOrganizationForm-inactive");
+        
+        // Simulate entering an invalid value (not "true" or "false")
+        fireEvent.change(inactiveField, { target: { value: 'invalid' } });
+        
+        // Simulate form submission
+        const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+        fireEvent.click(submitButton);
+    
+        // Check for the expected error message
+        const errorMessage = await screen.findByText("The input should be just true or false");
+        expect(errorMessage).toBeInTheDocument();
+    });
+    
+
     test("No Error messsages on good input", async () => {
 
         const mockSubmitAction = jest.fn();

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -69,6 +69,8 @@ describe("UCSBOrganizationForm tests", () => {
         fireEvent.click(submitButton);
 
         await screen.findByText(/orgTranslationShort is required./);
+
+        expect(screen.getByText(/orgCode is required./)).toBeInTheDocument();
         expect(screen.getByText(/orgTranslation is required./)).toBeInTheDocument();
         expect(screen.getByText(/inactive is required./)).toBeInTheDocument();
 

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -1,0 +1,125 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("UCSBOrganizationForm tests", () => {
+
+    test("renders correctly", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm />
+            </Router>
+        );
+        await screen.findByText(/Create/);
+    });
+
+    test("renders correctly when passing in a UCSBOrganization", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm initialContents={ucsbOrganizationFixtures.oneOrganization} />
+            </Router>
+        );
+        
+        await screen.findByTestId(/UCSBOrganizationForm-orgCode/);
+        expect(screen.getByText(/orgCode/)).toBeInTheDocument();
+        expect(screen.getByTestId(/UCSBOrganizationForm-orgCode/)).toHaveValue("VSA");
+    });
+
+
+    test("Correct Error messsages on bad input", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm />
+            </Router>
+        );
+        await screen.findByTestId("UCSBOrganizationForm-orgTranslationShort");
+        const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
+        const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
+        const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+        fireEvent.change(orgTranslationShortField, { target: { value: 'bad-input' } });
+        fireEvent.change(orgTranslationField, { target: { value: 'bad-input' } });
+        fireEvent.click(submitButton);
+
+        expect(screen.queryByText(/orgTranslationShort must be a string/)).not.toBeInTheDocument();
+    });
+
+    test("Correct Error messsages on missing input", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm />
+            </Router>
+        );
+        await screen.findByTestId("UCSBOrganizationForm-submit");
+        const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/orgTranslationShort is required./);
+        expect(screen.getByText(/orgTranslation is required./)).toBeInTheDocument();
+        expect(screen.getByText(/inactive is required./)).toBeInTheDocument();
+
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("UCSBOrganizationForm-orgTranslationShort");
+
+        const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+        const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
+        const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
+        const inactive = screen.getByTestId("UCSBOrganizationForm-inactive");
+        const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+        fireEvent.change(orgCodeField, { target: { value: 'VSA' } });
+        fireEvent.change(orgTranslationShortField, { target: { value: 'VIET STU ASSC' } });
+        fireEvent.change(orgTranslationField, { target: { value: 'VIETNAMESE STUDENT ASSOCIATION' } });
+        fireEvent.change(inactive, { target: { value: false } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(screen.queryByText(/orgTranslationShort must be a string/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/orgTranslation must be a string/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+
+        render(
+            <Router  >
+                <UCSBOrganizationForm />
+            </Router>
+        );
+        await screen.findByTestId("UCSBOrganizationForm-cancel");
+        const cancelButton = screen.getByTestId("UCSBOrganizationForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.js
@@ -1,0 +1,186 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBOrganizationTable tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["orgCode", "orgTranslationShort", "orgTranslation", "inactive"];
+    const expectedFields = ["orgCode", "orgTranslationShort", "orgTranslation", "inactive"];
+    const testId = "UCSBOrganizationTable";
+
+    test("renders empty table correctly", () => {
+    
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={ucsbOrganizationFixtures.threeOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("false");
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("false");
+
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={ucsbOrganizationFixtures.threeOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={ucsbOrganizationFixtures.threeOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsborganization/edit/VSA'));
+
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={ucsbOrganizationFixtures.threeOrganization} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("VIET STU ASSC");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("VIETNAMESE STUDENT ASSOCIATION");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+  });
+
+  
+});

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("UCSBOrganizationCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("on submit, makes request to backend, and redirects to /ucsborganization", async () => {
+
+        const queryClient = new QueryClient();
+        const organization = {
+            orgCode: "VSA",
+            orgTranslationShort: "VIET STU ASSC",
+            orgTranslation: "VIETNAMESE STUDENT ASSOCIATION",
+            inactive: "false"
+        };
+
+        axiosMock.onPost("/api/ucsborganization/post").reply(202, organization);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("orgCode")).toBeInTheDocument();
+        });
+
+        const orgCodeInput = screen.getByLabelText("orgCode");
+        expect(orgCodeInput).toBeInTheDocument();
+
+        const orgTranslationShortInput = screen.getByLabelText("orgTranslationShort");
+        expect(orgTranslationShortInput).toBeInTheDocument();
+
+        const orgTranslationInput = screen.getByLabelText("orgTranslation");
+        expect(orgTranslationInput).toBeInTheDocument();
+
+        const inactiveInput = screen.getByLabelText("inactive");
+        expect(inactiveInput).toBeInTheDocument();
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+
+        fireEvent.change(orgCodeInput, { target: { value: 'VSA' } })
+        fireEvent.change(orgTranslationShortInput, { target: { value: 'VIET STU ASSC' } })
+        fireEvent.change(orgTranslationInput, { target: { value: 'VIETNAMESE STUDENT ASSOCIATION' } })
+        fireEvent.change(inactiveInput, { target: { value: 'false' } })
+        fireEvent.click(createButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            orgCode: "VSA",
+            orgTranslationShort: "VIET STU ASSC",
+            orgTranslation: "VIETNAMESE STUDENT ASSOCIATION",
+            inactive: "false"
+        });
+
+        // assert - check that the toast was called with the expected message
+        expect(mockToast).toBeCalledWith("New organization Created - orgCode: VSA orgTranslationShort: VIET STU ASSC orgTranslation: VIETNAMESE STUDENT ASSOCIATION inactive: false");
+        expect(mockNavigate).toBeCalledWith({ "to": "/ucsborganization" });
+
+    });
+});

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.js
@@ -1,44 +1,186 @@
-import { render, screen } from "@testing-library/react";
-import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            orgCode: "VSA"
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("UCSBOrganizationEditPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    describe("when the backend doesn't return data", () => {
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/ucsborganization", { params: { orgCode : "VSA" } }).timeout();
+        });
 
-        setupUserOnly();
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <UCSBOrganizationEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+            const restoreConsole = mockConsole();
 
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBOrganizationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit UCSBOrganization");
+            expect(screen.queryByTestId("UCSBOrganization-orgCode")).not.toBeInTheDocument();
+            restoreConsole();
+        });
     });
 
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/ucsborganization", { params: { orgCode : "VSA" } }).reply(200, {
+                orgCode: "VSA",
+                orgTranslationShort: "VIET STU ASSC",
+                orgTranslation: "VIETNAMESE STUDENT ASSOCIATION",
+                inactive: "false"
+            });
+            axiosMock.onPut('/api/ucsborganization').reply(200, {
+                orgCode: "VSA1",
+                orgTranslationShort: "ASSC VIET STU",
+                orgTranslation: "ASSOCIATION FOR VIETNAMESE STUDENTS",
+                inactive: "true"
+            });
+        });
+
+        const queryClient = new QueryClient();
+    
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBOrganizationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+            const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+            const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
+            const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
+            const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
+            const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+            expect(orgCodeField).toBeInTheDocument();
+            expect(orgCodeField).toHaveValue("VSA");
+            expect(orgTranslationShortField).toBeInTheDocument();
+            expect(orgTranslationShortField).toHaveValue("VIET STU ASSC");
+            expect(orgTranslationField).toBeInTheDocument();
+            expect(orgTranslationField).toHaveValue("VIETNAMESE STUDENT ASSOCIATION");
+            expect(inactiveField).toBeInTheDocument();
+            expect(inactiveField).toHaveValue("false");
+
+            expect(submitButton).toHaveTextContent("Update");
+
+            fireEvent.change(orgCodeField, { target: { value: 'VSA1' } });
+            fireEvent.change(orgTranslationShortField, { target: { value: 'ASSC VIET STU' } });
+            fireEvent.change(orgTranslationField, { target: { value: 'ASSOCIATION FOR VIETNAMESE STUDENTS' } });
+            fireEvent.change(inactiveField, { target: { value: 'true' } });
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("UCSBOrganization Updated - orgCode: VSA1 orgTranslationShort: ASSC VIET STU orgTranslation: ASSOCIATION FOR VIETNAMESE STUDENTS inactive: true");
+            
+            expect(mockNavigate).toBeCalledWith({ "to": "/ucsborganization" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ orgCode : "VSA1" });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                orgCode: "VSA1",
+                orgTranslationShort: "ASSC VIET STU",
+                orgTranslation: "ASSOCIATION FOR VIETNAMESE STUDENTS",
+                inactive: "true"
+            })); // posted object
+
+
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBOrganizationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+            const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+            const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
+            const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
+            const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
+            const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+            expect(orgCodeField).toBeInTheDocument();
+            expect(orgCodeField).toHaveValue("VSA");
+            expect(orgTranslationShortField).toBeInTheDocument();
+            expect(orgTranslationShortField).toHaveValue("VIET STU ASSC");
+            expect(orgTranslationField).toBeInTheDocument();
+            expect(orgTranslationField).toHaveValue("VIETNAMESE STUDENT ASSOCIATION");
+            expect(inactiveField).toBeInTheDocument();
+            expect(inactiveField).toHaveValue("false");
+
+            fireEvent.change(orgCodeField, { target: { value: 'VSA1' } });
+            fireEvent.change(orgTranslationShortField, { target: { value: 'ASSC VIET STU' } });
+            fireEvent.change(orgTranslationField, { target: { value: 'ASSOCIATION FOR VIETNAMESE STUDENTS' } });
+            fireEvent.change(inactiveField, { target: { value: 'true' } });
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("UCSBOrganization Updated - orgCode: VSA1 orgTranslationShort: ASSC VIET STU orgTranslation: ASSOCIATION FOR VIETNAMESE STUDENTS inactive: true");
+            expect(mockNavigate).toBeCalledWith({ "to": "/ucsborganization" });
+        });
+
+
+       
+    });
 });
-
-

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("UCSBOrganizationEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
@@ -1,17 +1,30 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("UCSBOrganizationIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "UCSBOrganizationTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,13 +33,20 @@ describe("UCSBOrganizationIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+
     const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
 
-        setupUserOnly();
+    test("Renders with Create Button for admin user", async () => {
+        setupAdminUser();
+        axiosMock.onGet("/api/ucsborganization/all").reply(200, []);
 
-        // act
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -35,10 +55,101 @@ describe("UCSBOrganizationIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText(/Create Organization/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Organization/);
+        expect(button).toHaveAttribute("href", "/ucsborganization/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three organizations correctly for regular user", async () => {
+        setupUserOnly();
+        axiosMock.onGet("/api/ucsborganization/all").reply(200, ucsbOrganizationFixtures.threeOrganization);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("TT");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-orgCode`)).toHaveTextContent("DEM");
+
+        const createOrganizationButton = screen.queryByText("Create Organization");
+        expect(createOrganizationButton).not.toBeInTheDocument();
+
+        const orgTranslationShort = screen.getByText("VIET STU ASSC");
+        expect(orgTranslationShort).toBeInTheDocument();
+
+        const orgTranslation = screen.getByText("VIETNAMESE STUDENT ASSOCIATION");
+        expect(orgTranslation).toBeInTheDocument();
+
+        // const inactive = screen.getByText("false");
+        // expect(inactive).toBeInTheDocument();
+
+        // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
+        expect(screen.queryByTestId("UCSBOrganizationTable-cell-row-0-col-Delete-button")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("UCSBOrganizationTable-cell-row-0-col-Edit-button")).not.toBeInTheDocument();
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        axiosMock.onGet("/api/ucsborganization/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+        
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/ucsborganization/all");
+        restoreConsole();
+
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        axiosMock.onGet("/api/ucsborganization/all").reply(200, ucsbOrganizationFixtures.threeOrganization);
+        axiosMock.onDelete("/api/ucsborganization").reply(200, "UCSBOrganization with orgCode VSA was deleted");
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("VSA");
+
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("UCSBOrganization with orgCode VSA was deleted") });
+
+        await waitFor(() => { expect(axiosMock.history.delete.length).toBe(1); });
+        expect(axiosMock.history.delete[0].url).toBe("/api/ucsborganization");
+        expect(axiosMock.history.delete[0].url).toBe("/api/ucsborganization");
+        expect(axiosMock.history.delete[0].params).toEqual({ orgCode: "VSA" });
     });
 
 });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.js
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("UCSBOrganizationIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/utils/UCSBOrganizationUtils.test.js
+++ b/frontend/src/tests/utils/UCSBOrganizationUtils.test.js
@@ -1,0 +1,53 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/UCSBOrganizationUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBOrganizationUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { orgCode: "VSA" } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/ucsborganization",
+                method: "DELETE",
+                params: { orgCode: "VSA" }
+            });
+        });
+
+    });
+});

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,0 +1,107 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Tag(name = "UCSBOrganization")
+@RequestMapping("/api/ucsborganization")
+@RestController
+@Slf4j
+public class UCSBOrganizationController extends ApiController {
+
+    @Autowired
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @Operation(summary= "List all ucsb organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allOrganizations() {
+        Iterable<UCSBOrganization> organizations = ucsbOrganizationRepository.findAll();
+        return organizations;
+    }
+
+    @Operation(summary= "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrganization(
+        @Parameter(name="orgCode") @RequestParam String orgCode,
+        @Parameter(name="orgTranslationShort") @RequestParam String orgTranslationShort,
+        @Parameter(name="orgTranslation") @RequestParam String orgTranslation,
+        @Parameter(name="inactive") @RequestParam boolean inactive
+        )
+        {
+
+        UCSBOrganization organization = new UCSBOrganization();
+        organization.setOrgCode(orgCode);
+        organization.setOrgTranslationShort(orgTranslationShort);
+        organization.setOrgTranslation(orgTranslation);
+        organization.setInactive(inactive);
+
+        UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
+
+        return savedOrganization;
+    }
+
+    @Operation(summary= "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return organization;
+    }
+
+    @Operation(summary= "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        organization.setOrgCode(incoming.getOrgCode());
+        organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        organization.setOrgTranslation(incoming.getOrgTranslation());
+        organization.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(organization);
+
+        return organization;
+    }
+
+    @Operation(summary= "Delete a UCSBOrganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteCommons(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        ucsbOrganizationRepository.delete(organization);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganization")
+public class UCSBOrganization {
+    @Id
+    private String orgCode;
+    private String orgTranslationShort;
+    private String orgTranslation;
+    private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+ 
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -1,0 +1,395 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = UCSBOrganizationController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationControllerTests extends ControllerTestCase {
+   
+    @MockBean
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/ucsborganization/all
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsborganization/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsborganization/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(ucsbOrganizationRepository.findById(eq("TASA"))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=TASA"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(ucsbOrganizationRepository, times(1)).findById(eq("TASA"));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("UCSBOrganization with id TASA not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_organization() throws Exception {
+
+            // arrange
+
+            UCSBOrganization zetaPhiRho = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETA PHI RHO")
+                            .orgTranslation("ZETA PHI RHO")
+                            .inactive(false)
+                            .build();
+
+            UCSBOrganization skydiving = UCSBOrganization.builder()
+                            .orgCode("SKY")
+                            .orgTranslationShort("SKYDIVING CLUB")
+                            .orgTranslation("SKYDIVING CLUB AT UCSB")
+                            .inactive(false)
+                            .build();
+
+            UCSBOrganization studentLife = UCSBOrganization.builder()
+                            .orgCode("OSLI")
+                            .orgTranslationShort("STUDENT LIFE")
+                            .orgTranslation("OFFICE OF STUDENT LIFE")
+                            .inactive(false)
+                            .build();
+
+            UCSBOrganization koreanRadio = UCSBOrganization.builder()
+                            .orgCode("KRC")
+                            .orgTranslationShort("KOREAN RADIO CL")
+                            .orgTranslation("KOREAN RADIO CLUB")
+                            .inactive(false)
+                            .build();
+
+            ArrayList<UCSBOrganization> expectedOrganization = new ArrayList<>();
+            expectedOrganization.addAll(Arrays.asList(zetaPhiRho, skydiving, studentLife, koreanRadio));
+
+            when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganization);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsborganization/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(ucsbOrganizationRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedOrganization);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for POST /api/ucsborganization...
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsborganization/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/ucsborganization/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_organization() throws Exception {
+            // arrange
+
+            UCSBOrganization csu = UCSBOrganization.builder()
+                            .orgCode("CSU")
+                            .orgTranslationShort("CHINESE STU UN")
+                            .orgTranslation("CHINESE STUDENT UNION")
+                            .inactive(false)
+                            .build();
+
+            when(ucsbOrganizationRepository.save(eq(csu))).thenReturn(csu);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/ucsborganization/post?orgCode=CSU&orgTranslationShort=CHINESE STU UN&orgTranslation=CHINESE STUDENT UNION&inactive=false")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).save(csu);
+            String expectedJson = mapper.writeValueAsString(csu);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for GET /api/ucsborganization?...
+
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/ucsborganization?orgCode=ZPR"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+            // arrange
+
+            UCSBOrganization organization = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETA PHI RHO")
+                            .orgTranslation("ZETA PHI RHO")
+                            .inactive(false)
+                            .build();
+
+            when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(organization));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=ZPR"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(ucsbOrganizationRepository, times(1)).findById(eq("ZPR"));
+            String expectedJson = mapper.writeValueAsString(organization);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for PUT /api/ucsborganization?...
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_organization() throws Exception {
+            // arrange
+
+            UCSBOrganization zetaPhiRhoOrig = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETA PHI RHO")
+                            .orgTranslation("ZETA PHI RHO")
+                            .inactive(false)
+                            .build();
+
+            UCSBOrganization zetaPhiRhoEdited = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETAS")
+                            .orgTranslation("ZETA PHI RHOS")
+                            .inactive(true)
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(zetaPhiRhoEdited);
+
+            when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(zetaPhiRhoOrig));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/ucsborganization?orgCode=ZPR")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+            verify(ucsbOrganizationRepository, times(1)).save(zetaPhiRhoEdited); // should be saved with updated info
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+    }
+
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_organization_that_does_not_exist() throws Exception {
+            // arrange
+
+            UCSBOrganization editedOrg = UCSBOrganization.builder()
+                            .orgCode("TASA")
+                            .orgTranslationShort("TAI AMER STU ASSC")
+                            .orgTranslation("TAIWANESE AMERICAN STUDENT ASSOCIATION")
+                            .inactive(false)
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(editedOrg);
+
+            when(ucsbOrganizationRepository.findById(eq("TASA"))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/ucsborganization?orgCode=TASA")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findById("TASA");
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("UCSBOrganization with id TASA not found", json.get("message"));
+
+    }
+
+    // Tests for DELETE /api/ucsborganization?...
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_date() throws Exception {
+            // arrange
+
+            UCSBOrganization zetaPhiRho = UCSBOrganization.builder()
+                            .orgCode("ZPR")
+                            .orgTranslationShort("ZETA PHI RHO")
+                            .orgTranslation("ZETA PHI RHO")
+                            .inactive(false)
+                            .build();
+
+            when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(zetaPhiRho));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/ucsborganization?orgCode=ZPR")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+            verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("UCSBOrganization with id ZPR deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_organization_and_gets_right_error_message()
+                    throws Exception {
+            // arrange
+
+            when(ucsbOrganizationRepository.findById(eq("TASA"))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/ucsborganization?orgCode=TASA")
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).findById("TASA");
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("UCSBOrganization with id TASA not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_post_inactive_organization() throws Exception {
+        // arrange
+        UCSBOrganization vsa = UCSBOrganization.builder()
+                .orgCode("VSA")
+                .orgTranslationShort("Viet Stu Assc")
+                .orgTranslation("Vietnamese Student Association")
+                .inactive(true)
+                .build();
+
+        when(ucsbOrganizationRepository.save(eq(vsa))).thenReturn(vsa);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/ucsborganization/post?orgCode=VSA&orgTranslationShort=Viet Stu Assc&orgTranslation=Vietnamese Student Association&inactive=true")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).save(vsa);
+        String expectedJson = mapper.writeValueAsString(vsa);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+        }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_update_orgcode() throws Exception {
+        // arrange
+
+        UCSBOrganization zetaPhiRhoOrig = UCSBOrganization.builder()
+        .orgCode("ZPR")
+        .orgTranslationShort("ZETA PHI RHO")
+        .orgTranslation("ZETA PHI RHO")
+        .inactive(false)
+        .build();
+
+        UCSBOrganization zetaPhiRhoEdited = UCSBOrganization.builder()
+                .orgCode("ZPRNEW")
+                .orgTranslationShort("ZETAS")
+                .orgTranslation("ZETA PHI RHOS")
+                .inactive(true)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(zetaPhiRhoEdited);
+
+        when(ucsbOrganizationRepository.findById(eq("ZPR"))).thenReturn(Optional.of(zetaPhiRhoOrig));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/ucsborganization?orgCode=ZPR")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                                .content(requestBody)
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbOrganizationRepository, times(1)).findById("ZPR");
+        verify(ucsbOrganizationRepository, times(1)).save(zetaPhiRhoEdited); // should be saved with updated info
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(requestBody, responseString);
+    }
+}


### PR DESCRIPTION
In this PR, I implemented UCSBOrganization form and table components, which can be seen in storybook, and their tests. I also implemented UCSBOrganization Create, Edit, Index pages, and their tests.

100% coverage and mutation tests:
<img width="1041" alt="PNG image" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/91717567/7756438e-444a-48de-af96-4da01bf1f6cb">
<img width="663" alt="PNG image" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/91717567/6a28fbe1-bc31-49cf-a763-0c2261c09c42">

Dokku dev deployment: https://team03-gretchenlam-dev.dokku-13.cs.ucsb.edu/

Storybook: https://ucsb-cs156-w24.github.io/team03-w24-7pm-1/prs/77/storybook/?path=/story/components-ucsborganization-ucsborganizationform--create

Closes #19 
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24