### PR TITLE
zp - Added MenuItemReview form component and tests

### DIFF
--- a/frontend/src/fixtures/menuItemReviewFixtures.js
+++ b/frontend/src/fixtures/menuItemReviewFixtures.js
@@ -1,0 +1,39 @@
+const menuItemReviewFixtures = {
+    oneReview: {
+        "id": 1,
+        "itemId": "101",
+        "reviewerEmail": "localhost@dokku.com",
+        "stars": "2",
+        "dateReviewed": "2022-01-02T12:00:00",
+        "comments": "not the best i have had"
+    },
+    threeReview: [
+        {
+            "id": 1,
+            "itemId": "101",
+            "reviewerEmail": "localhost@dokku.com",
+            "stars": "2",
+            "dateReviewed": "2022-01-02T12:00:00",
+            "comments": "not the best i have had"
+        },
+        {
+            "id": 2,
+            "itemId": "102",
+            "reviewerEmail": "dokku@localhost.com",
+            "stars": "5",
+            "dateReviewed": "2021-04-22T11:07:32",
+            "comments": "the best ever!"
+        },
+        {
+            "id": 3,
+            "itemId": "103",
+            "reviewerEmail": "swagger@dokku.com",
+            "stars": "3",
+            "dateReviewed": "2022-11-05T10:20:05",
+            "comments": "meh meh"
+        }
+    ]
+};
+
+
+export { menuItemReviewFixtures };

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
@@ -1,0 +1,161 @@
+import { Button, Form, Row, Col } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+
+function MenuItemReviewForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+
+    const navigate = useNavigate();
+
+    // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+    // Note that even this complex regex may still need some tweaks
+
+    // Stryker disable next-line Regex
+    const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+
+            <Row>
+
+                {initialContents && (
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="id">Id</Form.Label>
+                            <Form.Control
+                                data-testid="MenuItemReviewForm-id"
+                                id="id"
+                                type="text"
+                                {...register("id")}
+                                value={initialContents.id}
+                                disabled
+                            />
+                        </Form.Group>
+                    </Col>
+                )}
+
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="itemId">Item ID</Form.Label>
+                            <Form.Control
+                                data-testid="MenuItemReviewForm-itemId"
+                                id="itemId"
+                                type="text"
+                                isInvalid={Boolean(errors.itemId)}
+                                {...register("itemId", { required: "Item Id is required" })}
+                            />
+                            <Form.Control.Feedback type="invalid">
+                                {errors.itemId && 'itemId is required.'}
+                                {errors.itemId?.message}
+                            </Form.Control.Feedback>
+                        </Form.Group>
+                    </Col>
+
+                    <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="reviewerEmail">Reviewer Email</Form.Label>
+                    <Form.Control
+                        data-testid={"MenuItemReviewForm-reviewerEmail"}
+                        id="reviewerEmail"
+                        type="text"
+                        isInvalid={Boolean(errors.name)}
+                        {...register("reviewerEmail", {
+                            required: "reviewerEmail is required."
+                        })}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.reviewerEmail?.message}
+                    </Form.Control.Feedback>
+                </Form.Group>
+
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="stars">Stars</Form.Label>
+                        <Form.Control
+                            data-testid="MenuItemReviewForm-stars"
+                            id="stars"
+                            type="text"
+                            isInvalid={Boolean(errors.itemId)}
+                            {...register("stars", { required: "Stars is required" })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.stars && 'stars is required.'}
+                            {errors.stars?.message}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="dateReviewed">Date Reviewed (iso format)</Form.Label>
+                        <Form.Control
+                            data-testid="MenuItemReviewForm-dateReviewed"
+                            id="dateReviewed"
+                            type="datetime-local"
+                            isInvalid={Boolean(errors.dateReviewed)}
+                            {...register("dateReviewed", { required: true, pattern: isodate_regex })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.dateReviewed && 'dateReviewed is required in iso format.'}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
+
+            <Row>
+
+                <Col>
+
+
+
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="comments">Comments</Form.Label>
+                        <Form.Control
+                            data-testid="MenuItemReviewForm-comments"
+                            id="comments"
+                            type="text"
+                            isInvalid={Boolean(errors.name)}
+                            {...register("comments", {
+                                required: "comments are required."
+                            })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.comments?.message}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
+
+            <Row>
+                <Col>
+                    <Button
+                        type="submit"
+                        data-testid="MenuItemReviewForm-submit"
+                    >
+                        {buttonLabel}
+                    </Button>
+                    <Button
+                        variant="Secondary"
+                        onClick={() => navigate(-1)}
+                        data-testid="MenuItemReviewForm-cancel"
+                    >
+                        Cancel
+                    </Button>
+                </Col>
+            </Row>
+        </Form>
+
+    )
+}
+
+export default MenuItemReviewForm;

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.js
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm"
+import { menuItemReviewFixtures } from 'fixtures/menuItemReviewFixtures';
+
+export default {
+    title: 'components/MenuItemReview/MenuItemReviewForm',
+    component: MenuItemReviewForm
+};
+
+
+const Template = (args) => {
+    return (
+        <MenuItemReviewForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: menuItemReviewFixtures.oneReview,
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.js
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.js
@@ -1,0 +1,129 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("MenuItemReviewForm tests", () => {
+
+    test("renders correctly", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm />
+            </Router>
+        );
+        await screen.findByText(/Item ID/);
+        await screen.findByText(/Create/);
+    });
+
+
+    test("renders correctly when passing in a MenuItemReview", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm initialContents={menuItemReviewFixtures.oneReview} />
+            </Router>
+        );
+        await screen.findByTestId(/MenuItemReviewForm-id/);
+        expect(screen.getByText(/Id/)).toBeInTheDocument();
+        expect(screen.getByTestId(/MenuItemReviewForm-id/)).toHaveValue("1");
+    });
+
+
+    test("Correct Error messsages on bad input", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm />
+            </Router>
+        );
+        await screen.findByTestId("MenuItemReviewForm-dateReviewed");
+        const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+        const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+        fireEvent.change(dateReviewedField, { target: { value: 'bad-input' } });
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/dateReviewed is required in iso format./);
+    });
+
+    test("Correct Error messsages on missing input", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm />
+            </Router>
+        );
+        await screen.findByTestId("MenuItemReviewForm-submit");
+        const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/dateReviewed is required in iso format./);
+        expect(screen.getByText(/itemId is required./)).toBeInTheDocument();
+        expect(screen.getByText(/reviewerEmail is required./)).toBeInTheDocument();
+        expect(screen.getByText(/stars is required./)).toBeInTheDocument();
+        expect(screen.getByText(/comments are required./)).toBeInTheDocument();
+
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <MenuItemReviewForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("MenuItemReviewForm-itemId");
+
+        const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+        const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
+        const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+        const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+        const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+        const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+        fireEvent.change(itemIdField, { target: { value: '1011' } });
+        fireEvent.change(reviewerEmailField, { target: { value: 'mutation@pitest.com' } });
+        fireEvent.change(starsField, { target: { value: '2' } });
+        fireEvent.change(dateReviewedField, { target: { value: '2022-01-02T12:00' } });
+        fireEvent.change(commentsField, { target: { value: 'not the best but not the worst' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(screen.queryByText(/DateReviewed must be in ISO format/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+
+        render(
+            <Router  >
+                <MenuItemReviewForm />
+            </Router>
+        );
+        await screen.findByTestId("MenuItemReviewForm-cancel");
+        const cancelButton = screen.getByTestId("MenuItemReviewForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});
+
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,121 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/menuitemreview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+    
+    @Autowired
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @Operation(summary= "List all Menu Item Reviews")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<MenuItemReview> allMenuItemReviews() {
+        Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
+        return reviews;
+    }
+
+    @Operation(summary= "Create a new Menu Item Review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public MenuItemReview postMenuItemReview(
+            @Parameter(name="itemId") @RequestParam long itemId,
+            @Parameter(name="reviewerEmail") @RequestParam String reviewerEmail,
+            @Parameter(name="stars") @RequestParam int stars,
+            @Parameter(name="dateReviewed", description = " (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateReviewed") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateReviewed,
+            @Parameter(name="comments") @RequestParam String comments)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("dateReviewed={}", dateReviewed);
+
+        MenuItemReview menuItemReview = new MenuItemReview();
+        menuItemReview.setItemId(itemId);
+        menuItemReview.setReviewerEmail(reviewerEmail);
+        menuItemReview.setStars(stars);
+        menuItemReview.setDateReviewed(dateReviewed);
+        menuItemReview.setComments(comments);
+
+        MenuItemReview savedmenuItemReview = menuItemReviewRepository.save(menuItemReview);
+
+        return savedmenuItemReview;
+    }
+
+    @Operation(summary= "Get a single Menu Item Review")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public MenuItemReview getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        return menuItemReview;
+    }
+
+    @Operation(summary= "Delete a Menu Item Review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReviewRepository.delete(menuItemReview);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
+
+    @Operation(summary= "Update a single Menu Item Review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public MenuItemReview updateMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid MenuItemReview incoming) {
+
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReview.setItemId(incoming.getItemId());
+        menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+        menuItemReview.setStars(incoming.getStars());
+        menuItemReview.setDateReviewed(incoming.getDateReviewed());
+        menuItemReview.setComments(incoming.getComments());
+
+        menuItemReviewRepository.save(menuItemReview);
+
+        return menuItemReview;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreview")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private long itemId;
+  private String reviewerEmail;
+  private int stars;
+  private LocalDateTime dateReviewed;
+  private String comments;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> {
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,339 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+    @MockBean
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/menuitemreview/all
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/menuitemreview/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/menuitemreview/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_menuitemreview() throws Exception {
+
+            // arrange
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                            .itemId(1123)
+                            .reviewerEmail("qwerty@qwert.com")
+                            .stars(3)
+                            .dateReviewed(ldt1)
+                            .comments("This is a comment")
+                            .build();
+
+            LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+            MenuItemReview menuItemReview2 = MenuItemReview.builder()
+                            .itemId(1723)
+                            .reviewerEmail("zpatel@uscb.edu")
+                            .stars(4)
+                            .dateReviewed(ldt2)
+                            .comments("This is a good comment")
+                            .build();
+
+            ArrayList<MenuItemReview> expectedReview = new ArrayList<>();
+            expectedReview.addAll(Arrays.asList(menuItemReview1, menuItemReview2));
+
+            when(menuItemReviewRepository.findAll()).thenReturn(expectedReview);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/menuitemreview/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(menuItemReviewRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedReview);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for POST /api/menuitemreview/post...
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/menuitemreview/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/menuitemreview/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_menuitemreview() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                            .itemId(1123)
+                            .reviewerEmail("qwerty@qwert.com")
+                            .stars(3)
+                            .dateReviewed(ldt1)
+                            .comments("This is a comment")
+                            .build();
+
+            when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/menuitemreview/post?itemId=1123&reviewerEmail=qwerty@qwert.com&stars=3&dateReviewed=2022-01-03T00:00:00&comments=This is a comment")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).save(menuItemReview1);
+            String expectedJson = mapper.writeValueAsString(menuItemReview1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for GET /api/menuitemreview?id=...
+
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/menuitemreview?id=123"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+            // arrange
+            LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview = MenuItemReview.builder()
+                            .itemId(1123)
+                            .reviewerEmail("qwerty@qwert.com")
+                            .stars(3)
+                            .dateReviewed(ldt)
+                            .comments("This is a comment")
+                            .build();
+
+            when(menuItemReviewRepository.findById(eq(123L))).thenReturn(Optional.of(menuItemReview));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=123"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(menuItemReviewRepository, times(1)).findById(eq(123L));
+            String expectedJson = mapper.writeValueAsString(menuItemReview);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(menuItemReviewRepository.findById(eq(123L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=123"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(menuItemReviewRepository, times(1)).findById(eq(123L));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("MenuItemReview with id 123 not found", json.get("message"));
+    }
+
+    // Tests for DELETE /api/menuitemreview?id=... 
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_review() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                            .itemId(1123)
+                            .reviewerEmail("qwerty@qwert.com")
+                            .stars(3)
+                            .dateReviewed(ldt1)
+                            .comments("This is a comment")
+                            .build();
+
+            when(menuItemReviewRepository.findById(eq(123L))).thenReturn(Optional.of(menuItemReview1));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/menuitemreview?id=123")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(123L);
+            verify(menuItemReviewRepository, times(1)).delete(any());
+
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("MenuItemReview with id 123 deleted", json.get("message"));
+    }
+    
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_menuitemreview_and_gets_right_error_message()
+                    throws Exception {
+            // arrange
+
+            when(menuItemReviewRepository.findById(eq(123L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/menuitemreview?id=123")
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(123L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("MenuItemReview with id 123 not found", json.get("message"));
+    }
+
+    // Tests for PUT /api/menuitemreview?id=... 
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+            LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+            
+            MenuItemReview menuItemReviewOrig = MenuItemReview.builder()
+                            .itemId(1123)
+                            .reviewerEmail("qwerty@qwert.com")
+                            .stars(3)
+                            .dateReviewed(ldt1)
+                            .comments("This is a comment")
+                            .build();
+
+            MenuItemReview menuItemReviewEdited = MenuItemReview.builder()
+                            .itemId(1723)
+                            .reviewerEmail("zpatel@uscb.edu")
+                            .stars(4)
+                            .dateReviewed(ldt2)
+                            .comments("This is a good comment")
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(menuItemReviewEdited);
+
+            when(menuItemReviewRepository.findById(eq(123L))).thenReturn(Optional.of(menuItemReviewOrig));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/menuitemreview?id=123")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(123L);
+            verify(menuItemReviewRepository, times(1)).save(menuItemReviewEdited); // should be saved with correct user
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+    }
+
+    
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+            
+            MenuItemReview menuItemEditedReview = MenuItemReview.builder()
+                            .itemId(1123)
+                            .reviewerEmail("qwerty@qwert.com")
+                            .stars(3)
+                            .dateReviewed(ldt1)
+                            .comments("This is a comment")
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(menuItemEditedReview);
+
+            when(menuItemReviewRepository.findById(eq(123L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/menuitemreview?id=123")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(123L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("MenuItemReview with id 123 not found", json.get("message"));
+
+    }
+
+}


### PR DESCRIPTION
Added form component for MenuItemReview and test that have 100% line and mutation coverage.

Storybook: https://ucsb-cs156-w24.github.io/team03-w24-7pm-1/prs/80/storybook/?path=/story/components-menuitemreview-menuitemreviewform--create

<img width="1292" alt="Screenshot 2024-02-15 at 12 21 52 PM" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/124837510/af234ba8-ba7c-40e3-9414-6264a006b081">
<img width="1292" alt="Screenshot 2024-02-15 at 12 22 00 PM" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/124837510/01ed2b05-dc64-4b1a-9424-9b756b0ae6b6">
<img width="1029" alt="Screenshot 2024-02-15 at 12 21 19 PM" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/124837510/6ef05ad2-1045-45cb-a75a-3fa5ca8c8de3">
<img width="586" alt="Screenshot 2024-02-15 at 12 21 37 PM" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/124837510/eb3b95c1-2af6-4108-a82a-66bd2922379b">

Closes #37 