### PR TITLE
OP - Copy Placeholders for UCSBDiningCommonsMenuItem pages; add to App.js/AppNavbar.js

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,9 +11,9 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
-import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
-import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
-import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
@@ -64,15 +64,15 @@ function App() {
          {
           hasRole(currentUser, "ROLE_USER") && (
             <>
-              <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />
+              <Route exact path="/ucsbdiningcommonsmenuitems" element={<UCSBDiningCommonsMenuItemIndexPage />} />
             </>
           )
         }
         {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
-              <Route exact path="/placeholder/edit/:id" element={<PlaceholderEditPage />} />
-              <Route exact path="/placeholder/create" element={<PlaceholderCreatePage />} />
+              <Route exact path="/UCSBDiningCommonsMenuItem/edit/:id" element={<UCSBDiningCommonsMenuItemEditPage />} />
+              <Route exact path="/UCSBDiningCommonsMenuItem/create" element={<UCSBDiningCommonsMenuItemCreatePage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -64,7 +64,7 @@ function App() {
               <Route exact path="/restaurants/create" element={<RestaurantCreatePage />} />
             </>
           )
-        }
+         }
         {
           hasRole(currentUser, "ROLE_USER") && (
             <>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
+import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
+import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
+
 import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
 import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
 import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
@@ -58,6 +62,21 @@ function App() {
             <>
               <Route exact path="/restaurants/edit/:id" element={<RestaurantEditPage />} />
               <Route exact path="/restaurants/create" element={<RestaurantCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/placeholder/edit/:id" element={<PlaceholderEditPage />} />
+              <Route exact path="/placeholder/create" element={<PlaceholderCreatePage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -64,15 +64,15 @@ function App() {
          {
           hasRole(currentUser, "ROLE_USER") && (
             <>
-              <Route exact path="/ucsbdiningcommonsmenuitems" element={<UCSBDiningCommonsMenuItemIndexPage />} />
+              <Route exact path="/diningcommonsmenuitem" element={<UCSBDiningCommonsMenuItemIndexPage />} />
             </>
           )
         }
         {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
-              <Route exact path="/UCSBDiningCommonsMenuItem/edit/:id" element={<UCSBDiningCommonsMenuItemEditPage />} />
-              <Route exact path="/UCSBDiningCommonsMenuItem/create" element={<UCSBDiningCommonsMenuItemCreatePage />} />
+              <Route exact path="/diningcommonsmenuitem/edit/:id" element={<UCSBDiningCommonsMenuItemEditPage />} />
+              <Route exact path="/diningcommonsmenuitem/create" element={<UCSBDiningCommonsMenuItemCreatePage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,7 +19,6 @@ import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenu
 import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
 import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
-
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -64,8 +63,8 @@ function App() {
               <Route exact path="/restaurants/create" element={<RestaurantCreatePage />} />
             </>
           )
-         }
-        {
+        }
+         {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />
@@ -80,7 +79,7 @@ function App() {
             </>
           )
         }
-         {
+        {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/diningcommonsmenuitem" element={<UCSBDiningCommonsMenuItemIndexPage />} />

--- a/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
+++ b/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
@@ -1,0 +1,38 @@
+const restaurantFixtures = {
+    oneRestaurant:
+    [
+      {
+       "id": 1,
+        "diningCommonsCode": "Carillo",
+        "name": "Burgers and Fries",
+        "station": "Sandwiches"      
+      }
+    ],
+
+    threeRestaurants:
+    [
+        {
+            "id": 2,
+             "diningCommonsCode": "Portola",
+             "name": "Bread",
+             "station": "Bakery"    
+        },
+
+        {
+            "id": 3,
+             "diningCommonsCode": "Ortega",
+             "name": "Burrito",
+             "station": "Mexican Grill"  
+        },
+
+        {
+            "id": 4,
+             "diningCommonsCode": "DLG",
+             "name": "Pizza",
+             "station": "Pizzeria"      
+        },
+        
+    ]
+};
+
+export { restaurantFixtures };

--- a/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
+++ b/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
@@ -1,5 +1,5 @@
-const restaurantFixtures = {
-    oneRestaurant:
+const ucsbDiningCommonsMenuItemFixtures = {
+    oneUCSBDiningCommonsMenuItem:
     [
       {
        "id": 1,
@@ -9,7 +9,7 @@ const restaurantFixtures = {
       }
     ],
 
-    threeRestaurants:
+    threeUCSBDiningCommonsMenuItem:
     [
         {
             "id": 2,
@@ -35,4 +35,4 @@ const restaurantFixtures = {
     ]
 };
 
-export { restaurantFixtures };
+export { ucsbDiningCommonsMenuItemFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -56,7 +56,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 <>
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
-                  <Nav.Link as={Link} to="/ucsbdiningcommonsmenuitems">UCSB Dining Commons Menu Items</Nav.Link>
+                  <Nav.Link as={Link} to="/diningcommonsmenuitem">UCSB Dining Commons Menu Items</Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -56,7 +56,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 <>
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
-                  <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
+                  <Nav.Link as={Link} to="/ucsbdiningcommonsmenuitems">UCSB Dining Commons Menu Items</Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -56,6 +56,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 <>
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
+                  <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
                   <Nav.Link as={Link} to="/diningcommonsmenuitem">UCSB Dining Commons Menu Items</Nav.Link>
                 </>
               )

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.js
@@ -1,0 +1,111 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+function UCSBDiningCommonsMenuItemForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+   
+    const navigate = useNavigate();
+
+    const testIdPrefix = "UCSBDiningCommonsMenuItemForm";
+
+    return (
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="id">Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-id"}
+                        id="id"
+                        type="text"
+                        {...register("id")}
+                        value={initialContents.id}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="name">Name</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-name"}
+                    id="name"
+                    type="text"
+                    isInvalid={Boolean(errors.name)}
+                    {...register("name", {
+                        required: "Name is required.",
+                        maxLength : {
+                            value: 30,
+                            message: "Max length 30 characters"
+                        }
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.name?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="diningCommonsCode">Dining Commons Code</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-diningCommonsCode"}
+                    id="diningCommonsCode"
+                    type="text"
+                    isInvalid={Boolean(errors.diningCommonsCode)}
+                    {...register("diningCommonsCode", {
+                        required: "Dining commons code is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.diningCommonsCode?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="station">Station</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-station"}
+                    id="station"
+                    type="text"
+                    isInvalid={Boolean(errors.station)}
+                    {...register("station", {
+                        required: "Station is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.station?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default UCSBDiningCommonsMenuItemForm;

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
@@ -1,0 +1,63 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDiningCommonsMenuItemUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function UCSBDiningCommonsMenuItemTable({
+    UCSBDiningCommonsMenuItems,
+    currentUser,
+    testIdPrefix = "UCSBDiningCommonsMenuItemTable"}) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/ucsbdiningcommonsmenuitems/${cell.row.values.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/UCSBDiningCommonsMenuItem/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+
+        {
+            Header: 'Name',
+            accessor: 'name',
+        },
+        {
+            Header: 'Dining Commons Code',
+            accessor: 'diningCommonsCode',
+        },
+        {
+            Header: 'Station',
+            accessor: 'station',
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix));
+    } 
+
+    return <OurTable
+        data={UCSBDiningCommonsMenuItems}
+        columns={columns}
+        testid={testIdPrefix}
+    />;
+};
+

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
@@ -14,7 +14,7 @@ export default function UCSBDiningCommonsMenuItemTable({
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
-        navigate(`/ucsbdiningcommonsmenuitems/${cell.row.values.id}`)
+        navigate(`/UCSBDiningCommonsMenuItem/edit/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
@@ -14,7 +14,7 @@ export default function UCSBDiningCommonsMenuItemTable({
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
-        navigate(`/UCSBDiningCommonsMenuItem/edit/${cell.row.values.id}`)
+        navigate(`/diningcommonsmenuitem/edit/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
@@ -1,0 +1,48 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function RestaurantCreatePage({storybook=false}) {
+
+  const objectToAxiosParams = (UCSBDiningCommonsMenuItem) => ({
+    url: "/api/UCSBDiningCommonsMenuItem/post",
+    method: "POST",
+    params: {
+     name: UCSBDiningCommonsMenuItem.name,
+     diningCommonsCode: UCSBDiningCommonsMenuItem.diningCommonsCode,
+     station: UCSBDiningCommonsMenuItem.station
+    }
+  });
+
+  const onSuccess = (UCSBDiningCommonsMenuItem) => {
+    toast(`New UCSB Dining Commons Menu Item created - id: ${UCSBDiningCommonsMenuItem.id} name: ${UCSBDiningCommonsMenuItem.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/UCSBDiningCommonsMenuItem/all"] // mutation makes this key stale so that pages relying on it reload
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsbdiningcommonsmenuitems" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New UCSBDiningCommonsMenuItem</h1>
+        <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
@@ -34,7 +34,7 @@ export default function RestaurantCreatePage({storybook=false}) {
   }
 
   if (isSuccess && !storybook) {
-    return <Navigate to="/ucsbdiningcommonsmenuitems" />
+    return <Navigate to="/diningcommonsmenuitem" />
   }
 
   return (

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
@@ -52,7 +52,7 @@ export default function UCSBDiningCommonsMenuItemEditPage({storybook=false}) {
     }
 
     if (isSuccess && !storybook) {
-        return <Navigate to="/ucsbdiningcommonsmenuitems" />
+        return <Navigate to="/diningcommonsmenuitem" />
     }
 
     return (

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
@@ -1,0 +1,69 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import UCSBDiningCommonsMenuItemForm from 'main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm';
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function UCSBDiningCommonsMenuItemEditPage({storybook=false}) {
+    let { id } = useParams();
+
+    const { data: UCSBDiningCommonsMenuItem, _error, _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/UCSBDiningCommonsMenuItem?id=${id}`],
+            {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/UCSBDiningCommonsMenuItem`,
+                params: {
+                    id
+                }
+            }
+        );
+
+    const objectToAxiosPutParams = (UCSBDiningCommonsMenuItem) => ({
+        url: "/api/UCSBDiningCommonsMenuItem",
+        method: "PUT",
+        params: {
+            id: UCSBDiningCommonsMenuItem.id,
+        },
+        data: {
+            name: UCSBDiningCommonsMenuItem.name,
+            diningCommonsCode: UCSBDiningCommonsMenuItem.diningCommonsCode,
+            station: UCSBDiningCommonsMenuItem.station
+        }
+    });
+
+    const onSuccess = (UCSBDiningCommonsMenuItem) => {
+        toast(`UCSBDiningCommonsMenuItem Updated - id: ${UCSBDiningCommonsMenuItem.id} name: ${UCSBDiningCommonsMenuItem.name}`);
+    }
+
+    const mutation = useBackendMutation(
+        objectToAxiosPutParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/UCSBDiningCommonsMenuItem?id=${id}`]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    }
+
+    if (isSuccess && !storybook) {
+        return <Navigate to="/ucsbdiningcommonsmenuitems" />
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Edit UCSBDiningCommonsMenuItem</h1>
+                {
+                    UCSBDiningCommonsMenuItem && <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={UCSBDiningCommonsMenuItem} />
+                }
+            </div>
+        </BasicLayout>
+    )
+
+}

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
@@ -24,7 +24,7 @@ export default function UCSBDiningCommonsMenuItemIndexPage() {
             return (
                 <Button
                     variant="primary"
-                    href="/UCSBDiningCommonsMenuItem/create"
+                    href="/diningcommonsmenuitem/create"
                     style={{ float: "right" }}
                 >
                     Create UCSBDiningCommonsMenuItem

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemTable from 'main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser'
+import { Button } from 'react-bootstrap';
+
+export default function UCSBDiningCommonsMenuItemIndexPage() {
+
+    const currentUser = useCurrentUser();
+
+    const { data: UCSBDiningCommonsMenuItems, error: _error, status: _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            ["/api/UCSBDiningCommonsMenuItem/all"],
+            { method: "GET", url: "/api/UCSBDiningCommonsMenuItem/all" },
+            // Stryker disable next-line all : don't test default value of empty list
+            []
+        );
+
+    const createButton = () => {
+        if (hasRole(currentUser, "ROLE_ADMIN")) {
+            return (
+                <Button
+                    variant="primary"
+                    href="/UCSBDiningCommonsMenuItem/create"
+                    style={{ float: "right" }}
+                >
+                    Create UCSBDiningCommonsMenuItem
+                </Button>
+            )
+        } 
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                {createButton()}
+                <h1>UCSBDiningCommonsMenuItems</h1>
+                <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={UCSBDiningCommonsMenuItems} currentUser={currentUser} />
+            </div>
+        </BasicLayout>
+    );
+}

--- a/frontend/src/main/utils/UCSBDiningCommonsMenuItemUtils.js
+++ b/frontend/src/main/utils/UCSBDiningCommonsMenuItemUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/UCSBDiningCommonsMenuItem",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+

--- a/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.stories.js
+++ b/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm"
+import { ucsbDiningCommonsMenuItemFixtures } from 'fixtures/ucsbDiningCommonsMenuItemFixtures';
+
+export default {
+    title: 'components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm',
+    component: UCSBDiningCommonsMenuItemForm
+};
+
+const Template = (args) => {
+    return (
+        <UCSBDiningCommonsMenuItemForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+         console.log("Submit was clicked with data: ", data); 
+         window.alert("Submit was clicked with data: " + JSON.stringify(data));
+    }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: ucsbDiningCommonsMenuItemFixtures.oneUCSBDiningCommonsMenuItem[0],
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuitemsTable.stories.js
+++ b/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuitemsTable.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import UCSBDiningCommonsMenuItemTable from 'main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable';
+import { ucsbDiningCommonsMenuItemFixtures } from 'fixtures/ucsbDiningCommonsMenuItemFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable',
+    component: UCSBDiningCommonsMenuItemTable
+};
+
+const Template = (args) => {
+    return (
+        <UCSBDiningCommonsMenuItemTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    UCSBDiningCommonsMenuItems: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    UCSBDiningCommonsMenuItems: ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    UCSBDiningCommonsMenuItems: ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/UCSBDiningCommonsMenuitem', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.test.js
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.test.js
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBDiningCommonsMenuItemtForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["Name", "Dining Commons Code", "Station"];
+    const testId = "UCSBDiningCommonsMenuItemForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBDiningCommonsMenuItemForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBDiningCommonsMenuItemForm initialContents={ucsbDiningCommonsMenuItemFixtures.oneUCSBDiningCommonsMenuItem} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+        expect(screen.getByText(`Id`)).toBeInTheDocument();
+
+        expect(await screen.findByTestId(`${testId}-name`)).toBeInTheDocument();
+        expect(screen.getByText(`Name`)).toBeInTheDocument();
+
+        expect(await screen.findByTestId(`${testId}-diningCommonsCode`)).toBeInTheDocument();
+        expect(screen.getByText(`Dining Commons Code`)).toBeInTheDocument();
+
+        expect(await screen.findByTestId(`${testId}-station`)).toBeInTheDocument();
+        expect(screen.getByText(`Station`)).toBeInTheDocument();
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBDiningCommonsMenuItemForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test("that the correct validations are performed", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBDiningCommonsMenuItemForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+        const submitButton = screen.getByText(/Create/);
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/Name is required/);
+        expect(screen.getByText(/Dining commons code is required/)).toBeInTheDocument();
+        expect(screen.getByText(/Station is required/)).toBeInTheDocument();
+
+        const nameInput = screen.getByTestId(`${testId}-name`);
+        fireEvent.change(nameInput, { target: { value: "a".repeat(31) } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Max length 30 characters/)).toBeInTheDocument();
+        });
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <UCSBDiningCommonsMenuItemForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("UCSBDiningCommonsMenuItemForm-name");
+
+        const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+        const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+        const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+        const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+        fireEvent.change(nameField, { target: { value: 'Carillo' } });
+        fireEvent.change(diningCommonsCodeField, { target: { value: 'Burgers and Fries' } });
+        fireEvent.change(stationField, { target: { value: 'Sandwiches' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(screen.queryByText(/Name is required/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Dining commons code is required/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Station is required/)).not.toBeInTheDocument();
+
+    });
+
+});

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
@@ -145,7 +145,7 @@ describe("UCSBDiningCommonsMenuItemTable tests", () => {
       fireEvent.click(editButton);
   
       // // assert - check that the navigate function was called with the expected path
-      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdiningcommonsmenuitems/2'));
+      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/UCSBDiningCommonsMenuItem/edit/2'));
   
     });
   
@@ -273,7 +273,7 @@ describe("UCSBDiningCommonsMenuItemTable tests", () => {
       
       fireEvent.click(editButton);
   
-      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdiningcommonsmenuitems/2'));
+      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/UCSBDiningCommonsMenuItem/edit/2'));
   
     });
 

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
@@ -145,7 +145,7 @@ describe("UCSBDiningCommonsMenuItemTable tests", () => {
       fireEvent.click(editButton);
   
       // // assert - check that the navigate function was called with the expected path
-      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/UCSBDiningCommonsMenuItem/edit/2'));
+      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/diningcommonsmenuitem/edit/2'));
   
     });
   
@@ -273,7 +273,7 @@ describe("UCSBDiningCommonsMenuItemTable tests", () => {
       
       fireEvent.click(editButton);
   
-      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/UCSBDiningCommonsMenuItem/edit/2'));
+      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/diningcommonsmenuitem/edit/2'));
   
     });
 

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
@@ -1,0 +1,281 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import UCSBDiningCommonsMenuItemTable from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBDiningCommonsMenuItemTable tests", () => {
+    const queryClient = new QueryClient();
+  
+    const expectedHeaders = ["id", "Name", "Dining Commons Code", "Station"];
+    const expectedFields = ["id", "name", "diningCommonsCode", "station"];
+    const testId = "UCSBDiningCommonsMenuItemTable";
+  
+    test("renders empty table correctly", () => {
+      
+      // arrange
+      const currentUser = currentUserFixtures.adminUser;
+  
+      // act
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={[]} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+  
+      // assert
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expectedFields.forEach((field) => {
+        const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(fieldElement).not.toBeInTheDocument();
+      });
+    });
+  
+    test("Has the expected column headers, content and buttons for admin user", () => {
+      // arrange
+      const currentUser = currentUserFixtures.adminUser;
+  
+      // act
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+  
+      // assert
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Bread");
+  
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("Burrito");
+  
+      const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+      expect(editButton).toBeInTheDocument();
+      expect(editButton).toHaveClass("btn-primary");
+  
+      const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+      expect(deleteButton).toBeInTheDocument();
+      expect(deleteButton).toHaveClass("btn-danger");
+  
+    });
+  
+    test("Has the expected column headers, content for ordinary user", () => {
+      // arrange
+      const currentUser = currentUserFixtures.userOnly;
+  
+      // act
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+  
+      // assert
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Bread");
+  
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("Burrito");
+  
+      expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+      expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    });
+  
+  
+    test("Edit button navigates to the edit page", async () => {
+      // arrange
+      const currentUser = currentUserFixtures.adminUser;
+  
+      // act - render the component
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+  
+      // assert - check that the expected content is rendered
+      expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Bread");
+  
+      const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+      expect(editButton).toBeInTheDocument();
+  
+      // act - click the edit button
+      fireEvent.click(editButton);
+  
+      // // assert - check that the navigate function was called with the expected path
+      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdiningcommonsmenuitems/2'));
+  
+    });
+  
+    test("Delete button calls delete callback", async () => {
+      // arrange
+      const currentUser = currentUserFixtures.adminUser;
+  
+      // act - render the component
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+      );
+  
+      // assert - check that the expected content is rendered
+      expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Bread");
+  
+      const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+      expect(deleteButton).toBeInTheDocument();
+  
+      // act - click the delete button
+      fireEvent.click(deleteButton);
+    });
+
+    // from UCSBDatesTable.test.js
+
+    test("Has the expected column headers and content for ordinary user", () => {
+
+      const currentUser = currentUserFixtures.userOnly;
+  
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+  
+      );
+  
+      const expectedHeaders = ["id", "Name", "Dining Commons Code", "Station"];
+      const expectedFields = ["id", "name", "diningCommonsCode", "station"];
+      const testId = "UCSBDiningCommonsMenuItemTable";
+  
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+  
+      const editButton = screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`);
+      expect(editButton).not.toBeInTheDocument();
+  
+      const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
+      expect(deleteButton).not.toBeInTheDocument();
+  
+    });
+  
+    test("Has the expected colum headers and content for adminUser", () => {
+  
+      const currentUser = currentUserFixtures.adminUser;
+  
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+  
+      );
+  
+      const expectedHeaders = ["id", "Name", "Dining Commons Code", "Station"];
+      const expectedFields = ["id", "name", "diningCommonsCode", "station"];
+      const testId = "UCSBDiningCommonsMenuItemTable";
+  
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+  
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+  
+      const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+      expect(editButton).toBeInTheDocument();
+      expect(editButton).toHaveClass("btn-primary");
+  
+      const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+      expect(deleteButton).toBeInTheDocument();
+      expect(deleteButton).toHaveClass("btn-danger");
+  
+    });
+  
+    test("Edit button navigates to the edit page for admin user", async () => {
+  
+      const currentUser = currentUserFixtures.adminUser;
+  
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemTable UCSBDiningCommonsMenuItems={ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem} currentUser={currentUser} />
+          </MemoryRouter>
+        </QueryClientProvider>
+  
+      );
+  
+      await waitFor(() => { expect(screen.getByTestId(`UCSBDiningCommonsMenuItemTable-cell-row-0-col-id`)).toHaveTextContent("2"); });
+  
+      const editButton = screen.getByTestId(`UCSBDiningCommonsMenuItemTable-cell-row-0-col-Edit-button`);
+      expect(editButton).toBeInTheDocument();
+      
+      fireEvent.click(editButton);
+  
+      await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbdiningcommonsmenuitems/2'));
+  
+    });
+
+  });
+  

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
@@ -103,7 +103,7 @@ describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
 
         // assert - check that the toast was called with the expected message
         expect(mockToast).toBeCalledWith("New UCSB Dining Commons Menu Item created - id: 2 name: Bread");
-        expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitems" });
+        expect(mockNavigate).toBeCalledWith({ "to": "/diningcommonsmenuitem" });
 
     });
 });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("on submit, makes request to backend, and redirects to /UCSBDiningCommonsMenuItem", async () => {
+
+        const queryClient = new QueryClient();
+        const UCSBDiningCommonsMenuItem = {
+            id: 2,
+            name: "Bread",
+            diningCommonsCode: "Portola",
+            station: "Bakery"
+        };
+
+        axiosMock.onPost("/api/UCSBDiningCommonsMenuItem/post").reply(202, UCSBDiningCommonsMenuItem);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Name")).toBeInTheDocument();
+        });
+
+        const nameInput = screen.getByLabelText("Name");
+        expect(nameInput).toBeInTheDocument();
+
+        const diningCommonsCodeInput = screen.getByLabelText("Dining Commons Code");
+        expect(diningCommonsCodeInput).toBeInTheDocument();
+
+        const stationInput = screen.getByLabelText("Station");
+        expect(stationInput).toBeInTheDocument();
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+
+        fireEvent.change(nameInput, { target: { value: 'Bread' } })
+        fireEvent.change(diningCommonsCodeInput, { target: { value: 'Portola' } })
+        fireEvent.change(stationInput, { target: { value: 'Bakery' } })
+        fireEvent.click(createButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            name: "Bread",
+            diningCommonsCode: "Portola",
+            station: "Bakery"
+        });
+
+        // assert - check that the toast was called with the expected message
+        expect(mockToast).toBeCalledWith("New UCSB Dining Commons Menu Item created - id: 2 name: Bread");
+        expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitems" });
+
+    });
+});
+
+

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
@@ -126,7 +126,7 @@ describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
             await waitFor(() => expect(mockToast).toBeCalled());
             expect(mockToast).toBeCalledWith("UCSBDiningCommonsMenuItem Updated - id: 17 name: Soft Serve Icecream");
             
-            expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitems" });
+            expect(mockNavigate).toBeCalledWith({ "to": "/diningcommonsmenuitem" });
 
             expect(axiosMock.history.put.length).toBe(1); // times called
             expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
@@ -173,7 +173,7 @@ describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
 
             await waitFor(() => expect(mockToast).toBeCalled());
             expect(mockToast).toBeCalledWith("UCSBDiningCommonsMenuItem Updated - id: 17 name: Soft Serve Icecream");
-            expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitems" });
+            expect(mockNavigate).toBeCalledWith({ "to": "/diningcommonsmenuitem" });
         });
 
        

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
@@ -1,0 +1,181 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
+
+    describe("when the backend doesn't return data", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit UCSBDiningCommonsMenuItem");
+            expect(screen.queryByTestId("UCSBDiningCommonsMenuItem-name")).not.toBeInTheDocument();
+            restoreConsole();
+        });
+    });
+
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                name: "Bread",
+                diningCommonsCode: "Portola",
+                station: "Bakery"
+            });
+            axiosMock.onPut('/api/UCSBDiningCommonsMenuItem').reply(200, {
+                id: 17,
+                name: "Soft Serve Icecream",
+                diningCommonsCode: "DLG",
+                station: "Desert"
+            });
+        });
+
+        const queryClient = new QueryClient();
+    
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBDiningCommonsMenuItemForm-id");
+
+            const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+            const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+            const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+            const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+            const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+            expect(idField).toBeInTheDocument();
+            expect(idField).toHaveValue("17");
+            expect(nameField).toBeInTheDocument();
+            expect(nameField).toHaveValue("Bread");
+            expect(diningCommonsCodeField).toBeInTheDocument();
+            expect(diningCommonsCodeField).toHaveValue("Portola");
+            expect(stationField).toBeInTheDocument();
+            expect(stationField).toHaveValue("Bakery");
+
+            expect(submitButton).toHaveTextContent("Update");
+
+            fireEvent.change(nameField, { target: { value: 'Soft Serve Icecream' } });
+            fireEvent.change(diningCommonsCodeField, { target: { value: 'DLG' } });
+            fireEvent.change(stationField, { target: { value: 'Desert' } });
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("UCSBDiningCommonsMenuItem Updated - id: 17 name: Soft Serve Icecream");
+            
+            expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitems" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                name: 'Soft Serve Icecream',
+                diningCommonsCode: 'DLG',
+                station: 'Desert'
+            })); // posted object
+
+
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBDiningCommonsMenuItemForm-id");
+
+            const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+            const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+            const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+            const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+            const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(nameField).toBeInTheDocument();
+            expect(nameField).toHaveValue("Bread");
+            expect(diningCommonsCodeField).toBeInTheDocument();
+            expect(diningCommonsCodeField).toHaveValue("Portola");
+            expect(stationField).toBeInTheDocument();
+            expect(stationField).toHaveValue("Bakery");
+
+            fireEvent.change(nameField, { target: { value: 'Soft Serve Icecream' } });
+            fireEvent.change(diningCommonsCodeField, { target: { value: 'DLG' } });
+            fireEvent.change(stationField, { target: { value: 'Desert' } });
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("UCSBDiningCommonsMenuItem Updated - id: 17 name: Soft Serve Icecream");
+            expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitems" });
+        });
+
+       
+    });
+});

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
@@ -59,7 +59,7 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
             expect(screen.getByText(/Create UCSBDiningCommonsMenuItem/)).toBeInTheDocument();
         });
         const button = screen.getByText(/Create UCSBDiningCommonsMenuItem/);
-        expect(button).toHaveAttribute("href", "/UCSBDiningCommonsMenuItem/create");
+        expect(button).toHaveAttribute("href", "/diningcommonsmenuitem/create");
         expect(button).toHaveAttribute("style", "float: right;");
     });
 

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
@@ -1,0 +1,154 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "UCSBDiningCommonsMenuItemTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+
+    const queryClient = new QueryClient();
+
+    test("Renders with Create Button for admin user", async () => {
+        setupAdminUser();
+        axiosMock.onGet("/api/UCSBDiningCommonsMenuItem/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(/Create UCSBDiningCommonsMenuItem/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create UCSBDiningCommonsMenuItem/);
+        expect(button).toHaveAttribute("href", "/UCSBDiningCommonsMenuItem/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three UCSBDiningCommonsMenuItems correctly for regular user", async () => {
+        setupUserOnly();
+        axiosMock.onGet("/api/UCSBDiningCommonsMenuItem/all").reply(200, ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+
+        const createUCSBDiningCommonsMenuItemButton = screen.queryByText("Create UCSBDiningCommonsMenuItem");
+        expect(createUCSBDiningCommonsMenuItemButton).not.toBeInTheDocument();
+
+        const name = screen.getByText("Bread");
+        expect(name).toBeInTheDocument();
+
+        const diningCommonsCode = screen.getByText("Portola");
+        expect(diningCommonsCode).toBeInTheDocument();
+
+        // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
+        expect(screen.queryByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-Delete-button")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("UCSBDiningCommonsMenuItemTable-cell-row-0-col-Edit-button")).not.toBeInTheDocument();
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        axiosMock.onGet("/api/restaurants/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+        
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/UCSBDiningCommonsMenuItem/all");
+        restoreConsole();
+
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        axiosMock.onGet("/api/UCSBDiningCommonsMenuItem/all").reply(200, ucsbDiningCommonsMenuItemFixtures.threeUCSBDiningCommonsMenuItem);
+        axiosMock.onDelete("/api/UCSBDiningCommonsMenuItem").reply(200, "UCSBDiningCommonsMenuItem with id 1 was deleted");
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("UCSBDiningCommonsMenuItem with id 1 was deleted") });
+
+        await waitFor(() => { expect(axiosMock.history.delete.length).toBe(1); });
+        expect(axiosMock.history.delete[0].url).toBe("/api/UCSBDiningCommonsMenuItem");
+        expect(axiosMock.history.delete[0].url).toBe("/api/UCSBDiningCommonsMenuItem");
+        expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
+    });
+
+});
+
+

--- a/frontend/src/tests/utils/UCSBDiningCommonsMenuItemUtils.test.js
+++ b/frontend/src/tests/utils/UCSBDiningCommonsMenuItemUtils.test.js
@@ -1,0 +1,58 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/UCSBDiningCommonsMenuItemUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBDiningCommonsMenuItemUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 17 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/UCSBDiningCommonsMenuItem",
+                method: "DELETE",
+                params: { id: 17 }
+            });
+        });
+
+    });
+});
+
+
+
+
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,110 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/UCSBDiningCommonsMenuItem")
+@RestController
+@Slf4j
+
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+    
+    @Autowired
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @Operation(summary= "List all UCSB Dining Commons menu items")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItem() {
+        Iterable<UCSBDiningCommonsMenuItem> UCSBDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findAll();
+        return UCSBDiningCommonsMenuItem;
+    }
+
+    @Operation(summary= "Create a UCSB Dining Commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+        @Parameter(name="diningCommonsCode") @RequestParam String diningCommonsCode,
+        @Parameter(name="name") @RequestParam String name,
+        @Parameter(name="station") @RequestParam String station
+        )
+        {
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
+        ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
+        ucsbDiningCommonsMenuItem.setName(name);
+        ucsbDiningCommonsMenuItem.setStation(station);
+
+        UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+        return savedUcsbDiningCommonsMenuItem;
+    }
+
+    @Operation(summary= "Get a single UCSB Dining Commons menu item")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBDiningCommonsMenuItem getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        return ucsbDiningCommonsMenuItem;
+    }
+
+    @Operation(summary= "Delete a UCSB Dining Commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteUCSBDiningCommonsMenuItem(
+            @Parameter(name="id") @RequestParam Long id) {
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        ucsbDiningCommonsMenuItemRepository.delete(ucsbDiningCommonsMenuItem);
+        return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
+    }
+
+    @Operation(summary= "Update a single UCSB Dining Commons menu item")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = ucsbDiningCommonsMenuItemRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+        ucsbDiningCommonsMenuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+        ucsbDiningCommonsMenuItem.setName(incoming.getName());
+        ucsbDiningCommonsMenuItem.setStation(incoming.getStation());
+
+        ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+        return ucsbDiningCommonsMenuItem;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,308 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase  {
+    @MockBean
+    UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests for GET /api/UCSBDiningCommonsMenuItem/all
+        
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                .andExpect(status().is(200)); // logged
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsbDiningCommonsMenuItem() throws Exception {
+
+        // arrange
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("ortega")
+                .name("bakedPestoPastaWithChicken")
+                .station("entreeSpecials")
+                .build();
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem2 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("ortega")
+                .name("tofuBanhMiSandwich(v)")
+                .station("entreeSpecials")
+                .build();
+
+        ArrayList<UCSBDiningCommonsMenuItem> expectedUCSBDiningCommonsMenuItem = new ArrayList<>();
+        expectedUCSBDiningCommonsMenuItem.addAll(Arrays.asList(ucsbDiningCommonsMenuItem1, ucsbDiningCommonsMenuItem2));
+
+        when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedUCSBDiningCommonsMenuItem);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedUCSBDiningCommonsMenuItem);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // Tests for POST /api/UCSBDiningCommonsMenuItem/post...
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/UCSBDiningCommonsMenuItem/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_ucsbDiningCommonsMenuItem() throws Exception {
+        // arrange
+
+        UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                .diningCommonsCode("ortega")
+                .name("bakedPestoPastaWithChicken")
+                .station("entreeSpecials")
+                .build();
+                
+        when(ucsbDiningCommonsMenuItemRepository.save(eq(ucsbDiningCommonsMenuItem1))).thenReturn(ucsbDiningCommonsMenuItem1);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/UCSBDiningCommonsMenuItem/post?diningCommonsCode=ortega&name=bakedPestoPastaWithChicken&station=entreeSpecials")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(ucsbDiningCommonsMenuItem1);
+        String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+        // Tests for GET /api/UCSBDiningCommonsMenuItemid=...
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("bakedPestoPastaWithChicken")
+                                .station("entreeSpecials")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+        
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
+        }
+
+        // Tests for DELETE /api/UCSBDiningCommonsMenuItem?id=... 
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_ucsbdiningcommonsmenuitem() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("bakedPestoPastaWithChicken")
+                                .station("entreeSpecials")
+                                .build();
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItem1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/UCSBDiningCommonsMenuItem?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDiningCommonsMenuItem with id 15 deleted", json.get("message"));
+        }
+        
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_UCSBDiningCommonsMenuItem_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/UCSBDiningCommonsMenuItem?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDiningCommonsMenuItem with id 15 not found", json.get("message"));
+        }
+        
+        // Tests for PUT /api/UCSBDiningCommonsMenuItem?id=... 
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_UCSBDiningCommonsMenuItem() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItemOrig = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("portola")
+                                .name("creamOfBroccoliSoup(v)")
+                                .station("greens&Grains")
+                                .build();
+
+                UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItemEdited = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("tofuBanhMiSandwich(v)")
+                                .station("entreeSpecials")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ucsbDiningCommonsMenuItemEdited);
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDiningCommonsMenuItemOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/UCSBDiningCommonsMenuItem?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(ucsbDiningCommonsMenuItemEdited); // should be saved with correct user
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_UCSBDiningCommonsMenuItem_that_does_not_exist() throws Exception {
+                // arrange
+
+                UCSBDiningCommonsMenuItem ucsbEditedDiningCommonsMenuItem = UCSBDiningCommonsMenuItem.builder()
+                                .diningCommonsCode("ortega")
+                                .name("bakedPestoPastaWithChicken")
+                                .station("entreeSpecials")
+                                .build();
+
+                String requestBody = mapper.writeValueAsString(ucsbEditedDiningCommonsMenuItem);
+
+                when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/UCSBDiningCommonsMenuItem?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBDiningCommonsMenuItem with id 67 not found", json.get("message"));
+
+        }
+}


### PR DESCRIPTION
For UCSBDiningCommonsMenuItem, added pages for index, create, and edit. Updated the App.js and AppNavbar.js to include these new pages. To test, make sure that you can create, edit, and view UCSBDiningCommonsMenuItems. Each item is supposed to have a "Name", "Dining Commons Code", and "Station". Dev deployment here: https://team03-owenjpark-dev.dokku-13.cs.ucsb.edu

<img width="1350" alt="Screenshot 2024-02-16 at 2 40 10 PM" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/96025896/a1655f4b-ee24-41b3-b2a1-6c9085007e6c">
<img width="1424" alt="Screenshot 2024-02-16 at 2 39 30 PM" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/96025896/57efbc94-702b-4d2b-81aa-5af3620e901c">
<img width="1359" alt="Screenshot 2024-02-16 at 2 39 26 PM" src="https://github.com/ucsb-cs156-w24/team03-w24-7pm-1/assets/96025896/63dc72ca-4fbd-4a01-9866-16d98dfcbc8e">

Closes #12 
Closes #13 